### PR TITLE
task definition에 환경변수 추가

### DIFF
--- a/.github/ecs/task-definition.json
+++ b/.github/ecs/task-definition.json
@@ -68,6 +68,10 @@
                 {
                     "name": "APPLE_KEY_PATH",
                     "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:650553045794:secret:java-b6ARto:APPLE_KEY_PATH::"
+                },
+                {
+                "name": "SPRING_PROFILES_ACTIVE",
+                "value": "local"
                 }
             ],
             "ulimits": [],


### PR DESCRIPTION
## 📝작업 내용

task definition의 환경변수에 spring_profiles_active를 추가하여 스프링이 올바른 profile을 참조하도록 수정했습니다.