### PR TITLE
[BE-4] refactor: 카카오 로그인 로직 수정

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/auth/dto/kakao/KaKaoUserInfoRes.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/dto/kakao/KaKaoUserInfoRes.java
@@ -1,28 +1,25 @@
 package com.econo_4factorial.newproject.auth.dto.kakao;
 
-import com.econo_4factorial.newproject.user.dto.UserInfoDTO;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record KaKaoUserInfoRes(
+    Long id,
+    @JsonProperty("kakao_account")
     KakaoAccount kakaoAccount
 ) {
 
     public record KakaoAccount(
             String email,
-            String name,
-            String phoneNumber
+            String name
     ) {
-        public KakaoAccount (String email, String name, String phoneNumber) {
+        public KakaoAccount (String email, String name) {
             this.email = email;
             this.name = name;
-            this.phoneNumber = formatPhoneNumber(phoneNumber);
         }
 
-        private String formatPhoneNumber(String phoneNumber) {
-            return phoneNumber.replace("+82 ", "0");
-        }
     }
 
-    public UserInfoDTO toUserInfoDTO() {
-        return new UserInfoDTO(this.kakaoAccount.email, this.kakaoAccount.name, this.kakaoAccount.phoneNumber);
+    public KakaoUserInfoDTO toKaKaoUserInfoDTO() {
+        return new KakaoUserInfoDTO(this.id, this.kakaoAccount.email, this.kakaoAccount.name);
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/auth/dto/kakao/KakaoTokenRes.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/dto/kakao/KakaoTokenRes.java
@@ -1,10 +1,17 @@
 package com.econo_4factorial.newproject.auth.dto.kakao;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record KakaoTokenRes(
+        @JsonProperty("token_type")
         String tokenType,
+        @JsonProperty("access_token")
         String accessToken,
-        Integer expires_in,
-        String refresh_token,
-        Integer refresh_token_expires_in
+        @JsonProperty("expires_in")
+        Integer expiresIn,
+        @JsonProperty("refresh_token")
+        String refreshToken,
+        @JsonProperty("refresh_token_expires_in")
+        Integer refreshTokenExpiresIn
 ) {
 }

--- a/src/main/java/com/econo_4factorial/newproject/auth/dto/kakao/KakaoUserInfoDTO.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/dto/kakao/KakaoUserInfoDTO.java
@@ -1,0 +1,8 @@
+package com.econo_4factorial.newproject.auth.dto.kakao;
+
+public record KakaoUserInfoDTO(
+        Long kakaoId,
+        String email,
+        String name
+) {
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/service/kakao/KaKaoOAuthService.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/service/kakao/KaKaoOAuthService.java
@@ -1,7 +1,7 @@
 package com.econo_4factorial.newproject.auth.service.kakao;
 
 import com.econo_4factorial.newproject.auth.dto.kakao.KaKaoUserInfoRes;
-import com.econo_4factorial.newproject.user.dto.UserInfoDTO;
+import com.econo_4factorial.newproject.auth.dto.kakao.KakaoUserInfoDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -16,12 +16,12 @@ public class KaKaoOAuthService {
     private static final String RESPONSE_TYPE = "code";
     private static final String GRANT_TYPE = "authorization_code";
     private static final String TOKEN_PRIFIX = "bearer ";
-    private static final String PROPERTIES = "[\"kakao_account.email\", \"kakao_account.name\", \"kakao_account.phone_number\"]";
+    private static final String PROPERTIES = "[\"kakao_account.name\", \"kakao_account.email\"]";
 
     @Value("${oauth.kakao.client-id}")
     private String client_id;
 
-    @Value("${oauth.kakao.url.redirect-uri}")
+    @Value("${oauth.kakao.uri.redirect-uri}")
     private String redirect_uri;
 
     public String getLoginURI() {
@@ -34,10 +34,10 @@ public class KaKaoOAuthService {
                 .toUriString();
     }
 
-    public UserInfoDTO getUserInfo(String kakaoAuthorizationCode) {
+    public KakaoUserInfoDTO getUserInfo(String kakaoAuthorizationCode) {
         String kakaoAccessToken = getAccessToken(kakaoAuthorizationCode);
         KaKaoUserInfoRes kaKaoUserInfo = kakaoUserInfoFeignClient.getUserInfo(TOKEN_PRIFIX + kakaoAccessToken, PROPERTIES );
-        return kaKaoUserInfo.toUserInfoDTO();
+        return kaKaoUserInfo.toKaKaoUserInfoDTO();
     }
 
     private String getAccessToken(String kakaoAuthorizationCode) {

--- a/src/main/java/com/econo_4factorial/newproject/common/config/webConfig.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/config/webConfig.java
@@ -1,0 +1,17 @@
+package com.econo_4factorial.newproject.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class webConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("https://localhost:3000", "http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.econo_4factorial.newproject.common.exception;
 
-import com.econo_4factorial.newproject.auth.exception.BadRequestExeption.AuthException;
+import com.econo_4factorial.newproject.auth.exception.BadRequestException.AuthException;
 import com.econo_4factorial.newproject.common.util.HttpHeadersGenerator;
 import com.econo_4factorial.newproject.common.util.RedirectUriBuilder;
 import com.econo_4factorial.newproject.common.util.api.ApiResponse;

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/UserInfoDTO.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/UserInfoDTO.java
@@ -2,6 +2,5 @@ package com.econo_4factorial.newproject.user.dto;
 
 public record UserInfoDTO (
         String email,
-        String name,
-        String phoneNumber
+        String name
 ) {}

--- a/src/main/resources/application-kakao.yml
+++ b/src/main/resources/application-kakao.yml
@@ -6,6 +6,5 @@ spring:
 oauth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
-    url:
+    uri:
       redirect-uri: ${KAKAO_REDIRECT_URI}
-    response-type: ${KAKAO_RESPONSE_TYPE}


### PR DESCRIPTION
## #️⃣연관된 이슈

#20 

## 📝작업 내용

- 이메일, 이름만 카카오로부터 수집하도록 리팩터링
- 카카오 로그인 중복 가입 방지를 위해 카카오에서 제공하는 사용자 식별 번호를 받도록 리팩터링
- CORS 설정 및 webConfig 파일 구현
- 카카오 응답에 대해서 camel케이스로 역직렬화 되게끔 어노테이션 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

리뷰 잘 부탁드립니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 카카오 사용자 정보를 담는 새로운 DTO가 추가되었습니다.
    - CORS 설정이 도입되어 로컬 개발 환경(포트 3000)에서의 접근이 허용됩니다.

- **Bug Fixes**
    - 예외 처리 관련 오타가 수정되었습니다.

- **Refactor**
    - 카카오 사용자 정보 및 토큰 관련 데이터 구조가 개선되어, 필드명과 반환 타입이 일관성 있게 변경되었습니다.
    - 사용자 정보에서 전화번호 필드가 제거되었습니다.
    - 설정 파일의 일부 키 값이 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->