### PR TITLE
[BE-5] feat: 애플 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     //implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
@@ -1,14 +1,17 @@
 package com.econo_4factorial.newproject.auth.controller;
 
-import com.econo_4factorial.newproject.auth.dto.Res.LoginRes;
+import com.econo_4factorial.newproject.auth.dto.Req.AppleLoginReq;
+import com.econo_4factorial.newproject.auth.jwt.AuthToken;
 import com.econo_4factorial.newproject.auth.service.OAuthService;
+import com.econo_4factorial.newproject.common.util.HttpHeadersGenerator;
+import com.econo_4factorial.newproject.common.util.RedirectUriBuilder;
+import com.econo_4factorial.newproject.common.util.api.ApiResponse;
+import com.econo_4factorial.newproject.common.util.api.ApiResult;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.net.URI;
 
 @AllArgsConstructor
 @RestController
@@ -16,18 +19,23 @@ import java.net.URI;
 public class OAuthController {
     private final OAuthService oAuthService;
 
-    @GetMapping("kakao")
-    public ResponseEntity<Void> getKakaoLoginUri() {
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.setLocation(URI.create(oAuthService.getKakaoLoginURI()));
-        return new ResponseEntity<>(httpHeaders, HttpStatus.FOUND);
+    @PostMapping("/kakao/login")
+    public ApiResult<ApiResult.SuccessBody<Void>> getKakaoLoginUri() {
+        HttpHeaders headers = HttpHeadersGenerator.setLocation(oAuthService.getKakaoLoginURI());
+        return ApiResponse.success(headers, HttpStatus.FOUND);
     }
 
-    @GetMapping("/kakao-redirect")
-    public ResponseEntity<LoginRes> loginWithKakao (@RequestParam("code") String kakaoAuthorizationCode) {
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.setLocation(URI.create("")); //추후 프론트 주소로 수정 필요
-        LoginRes authToken = oAuthService.loginWithKaKao(kakaoAuthorizationCode);
-        return new ResponseEntity<>(httpHeaders, HttpStatus.FOUND);
+    @GetMapping("/kakao/callback")
+    public ApiResult<ApiResult.SuccessBody<Void>> loginWithKakao (@RequestParam("code") String kakaoAuthorizationCode) {
+        AuthToken authToken = oAuthService.loginWithKaKao(kakaoAuthorizationCode);
+        HttpHeaders headers = HttpHeadersGenerator.setLocation(RedirectUriBuilder.buildLoginSuccessUri(authToken));
+        return ApiResponse.success(headers, HttpStatus.FOUND);
+    }
+
+    @PostMapping("/apple/login")
+    public ApiResult<ApiResult.SuccessBody<Void>> loginWithApple (@RequestBody @Valid AppleLoginReq appleLoginReq) {
+        AuthToken authToken = oAuthService.loginWithApple(appleLoginReq);
+        HttpHeaders headers = HttpHeadersGenerator.setLocation(RedirectUriBuilder.buildLoginSuccessUri(authToken));
+        return ApiResponse.success(headers, HttpStatus.FOUND);
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/auth/dto/Req/AppleLoginReq.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/dto/Req/AppleLoginReq.java
@@ -1,0 +1,24 @@
+package com.econo_4factorial.newproject.auth.dto.Req;
+
+import com.econo_4factorial.newproject.auth.dto.apple.AppleUserInfoDTO;
+import com.econo_4factorial.newproject.common.annotation.ValidEmailPattern;
+import com.econo_4factorial.newproject.common.exception.ValidationMessage;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+public record AppleLoginReq(
+        @NotBlank(message = ValidationMessage.IDENTITY_TOKEN_REQUIRED)
+        String identityToken,
+
+        @NotBlank(message = ValidationMessage.EMAIL_INVALID_PATTERN)
+        @ValidEmailPattern
+        String email,
+
+        @Valid
+        FullName fullName
+) {
+        public AppleUserInfoDTO toAppleUserInfoDTO(String appleSub) {
+                String name = this.fullName.familyName()+this.fullName.givenName();
+                return new AppleUserInfoDTO(appleSub, name, this.email);
+        }
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/dto/Req/FullName.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/dto/Req/FullName.java
@@ -1,0 +1,13 @@
+package com.econo_4factorial.newproject.auth.dto.Req;
+
+import com.econo_4factorial.newproject.common.exception.ValidationMessage;
+import jakarta.validation.constraints.NotBlank;
+
+public record FullName(
+        @NotBlank(message = ValidationMessage.FAMILY_NAME_REQUIRED)
+        String familyName,
+
+        @NotBlank(message = ValidationMessage.GIVEN_NAME_REQUIRED)
+        String givenName
+) {
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/dto/Res/LoginRes.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/dto/Res/LoginRes.java
@@ -1,7 +1,0 @@
-package com.econo_4factorial.newproject.auth.dto.Res;
-
-public record LoginRes(
-        String accessToken,
-        String refreshToken
-) {
-}

--- a/src/main/java/com/econo_4factorial/newproject/auth/dto/apple/ApplePublicKeysResponse.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/dto/apple/ApplePublicKeysResponse.java
@@ -1,0 +1,16 @@
+package com.econo_4factorial.newproject.auth.dto.apple;
+
+import java.util.List;
+
+public record ApplePublicKeysResponse(
+        List<ApplePublicKey> keys
+) {
+    public record ApplePublicKey(
+        String kty,
+        String kid,
+        String use,
+        String alg,
+        String n,
+        String e
+    ) {}
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/dto/apple/AppleUserInfoDTO.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/dto/apple/AppleUserInfoDTO.java
@@ -1,0 +1,9 @@
+package com.econo_4factorial.newproject.auth.dto.apple;
+
+public record AppleUserInfoDTO(
+        String appleSub,
+        String name,
+        String email
+
+) {
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/exception/AuthErrorType.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/exception/AuthErrorType.java
@@ -1,0 +1,41 @@
+package com.econo_4factorial.newproject.auth.exception;
+
+import com.econo_4factorial.newproject.common.exception.ErrorType;
+import org.springframework.http.HttpStatus;
+
+public enum AuthErrorType implements ErrorType {
+    AUTH_EXCEPTION ("Auth400_001", HttpStatus.FOUND, "로그인 과정 중 에러가 발생했습니다"),
+    INVALID_TOKEN_EXCEPTION("Auth401_001", HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다"),
+    EXPIRED_TOKEN_EXCEPTION("Auth401_002", HttpStatus.BAD_REQUEST, "만료된 토큰입니다"),
+
+    APPLE_TOKEN_HEADER_PARSING_EXCEPTION("Auth500_001", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken헤더 파싱 중 에러가 발생했습니다"),
+    NOT_MATCHED_APPLE_PUBLIC_KEY_EXCEPTION("Auth500_002", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken의 서명(signature) 검증 중 매칭되는 공개키를 찾을 수 없습니다"),
+    APPLE_PUBLIC_KEY_GENERATE_EXCEPTION ("Auth500_003", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken의 서명(signature) 검증에서 사용되는 공개키 생성 중 에러가 발생했습니다"),
+    NOT_APPLE_ISSUER_EXCEPTION("Auth500_004", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken 검증 중 issuer가 애플이 아닙니다"),
+    INVALID_AUDIENCE_EXCEPTION("Auth500_005", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken 검증 중 audience가 client_id가 아닙니다");
+
+    private final String errorCode;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    AuthErrorType(String errorCode, HttpStatus httpStatus, String message) {
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/exception/BadRequestException/AuthException.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/exception/BadRequestException/AuthException.java
@@ -1,0 +1,10 @@
+package com.econo_4factorial.newproject.auth.exception.BadRequestException;
+
+import com.econo_4factorial.newproject.auth.exception.AuthErrorType;
+import com.econo_4factorial.newproject.common.exception.BadRequestException;
+
+public class AuthException extends BadRequestException {
+    public AuthException() {
+        super(AuthErrorType.AUTH_EXCEPTION);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/exception/BadRequestException/ExpiredTokenException.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/exception/BadRequestException/ExpiredTokenException.java
@@ -1,0 +1,10 @@
+package com.econo_4factorial.newproject.auth.exception.BadRequestException;
+
+import com.econo_4factorial.newproject.auth.exception.AuthErrorType;
+import com.econo_4factorial.newproject.common.exception.BadRequestException;
+
+public class ExpiredTokenException extends BadRequestException {
+    public ExpiredTokenException() {
+        super(AuthErrorType.EXPIRED_TOKEN_EXCEPTION);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/exception/BadRequestException/InvalidTokenException.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/exception/BadRequestException/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package com.econo_4factorial.newproject.auth.exception.BadRequestException;
+
+import com.econo_4factorial.newproject.auth.exception.AuthErrorType;
+import com.econo_4factorial.newproject.common.exception.BadRequestException;
+
+public class InvalidTokenException extends BadRequestException {
+    public InvalidTokenException() {
+        super(AuthErrorType.INVALID_TOKEN_EXCEPTION);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/exception/InternalServerException/ApplePublicKeyGenerateException.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/exception/InternalServerException/ApplePublicKeyGenerateException.java
@@ -1,0 +1,10 @@
+package com.econo_4factorial.newproject.auth.exception.InternalServerException;
+
+import com.econo_4factorial.newproject.auth.exception.AuthErrorType;
+import com.econo_4factorial.newproject.common.exception.InternalServerException;
+
+public class ApplePublicKeyGenerateException extends InternalServerException {
+    public ApplePublicKeyGenerateException () {
+        super(AuthErrorType.APPLE_PUBLIC_KEY_GENERATE_EXCEPTION);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/exception/InternalServerException/AppleTokenHeaderParsingException.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/exception/InternalServerException/AppleTokenHeaderParsingException.java
@@ -1,0 +1,10 @@
+package com.econo_4factorial.newproject.auth.exception.InternalServerException;
+
+import com.econo_4factorial.newproject.auth.exception.AuthErrorType;
+import com.econo_4factorial.newproject.common.exception.InternalServerException;
+
+public class AppleTokenHeaderParsingException extends InternalServerException {
+    public AppleTokenHeaderParsingException() {
+        super(AuthErrorType.APPLE_TOKEN_HEADER_PARSING_EXCEPTION);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/exception/InternalServerException/InvalidAudienceException.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/exception/InternalServerException/InvalidAudienceException.java
@@ -1,0 +1,10 @@
+package com.econo_4factorial.newproject.auth.exception.InternalServerException;
+
+import com.econo_4factorial.newproject.auth.exception.AuthErrorType;
+import com.econo_4factorial.newproject.common.exception.InternalServerException;
+
+public class InvalidAudienceException extends InternalServerException {
+    public InvalidAudienceException() {
+        super(AuthErrorType.INVALID_AUDIENCE_EXCEPTION);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/exception/InternalServerException/NotAppleIssuerException.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/exception/InternalServerException/NotAppleIssuerException.java
@@ -1,0 +1,10 @@
+package com.econo_4factorial.newproject.auth.exception.InternalServerException;
+
+import com.econo_4factorial.newproject.auth.exception.AuthErrorType;
+import com.econo_4factorial.newproject.common.exception.InternalServerException;
+
+public class NotAppleIssuerException extends InternalServerException {
+    public NotAppleIssuerException() {
+        super(AuthErrorType.NOT_APPLE_ISSUER_EXCEPTION);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/exception/InternalServerException/NotMatchedApplePublicKeyException.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/exception/InternalServerException/NotMatchedApplePublicKeyException.java
@@ -1,0 +1,10 @@
+package com.econo_4factorial.newproject.auth.exception.InternalServerException;
+
+import com.econo_4factorial.newproject.auth.exception.AuthErrorType;
+import com.econo_4factorial.newproject.common.exception.InternalServerException;
+
+public class NotMatchedApplePublicKeyException extends InternalServerException {
+    public NotMatchedApplePublicKeyException() {
+        super(AuthErrorType.NOT_MATCHED_APPLE_PUBLIC_KEY_EXCEPTION);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/jwt/service/JwtTokenProvider.java
@@ -1,11 +1,15 @@
 package com.econo_4factorial.newproject.auth.jwt.service;
 
+import com.econo_4factorial.newproject.auth.exception.BadRequestException.ExpiredTokenException;
+import com.econo_4factorial.newproject.auth.exception.BadRequestException.InvalidTokenException;
 import com.econo_4factorial.newproject.auth.jwt.RefreshToken;
 import com.econo_4factorial.newproject.auth.jwt.TokenType;
 import com.econo_4factorial.newproject.auth.jwt.repository.RefreshTokenRepository;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -85,8 +89,10 @@ public class JwtTokenProvider {
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Invalid token", e);
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException();
+        } catch (SignatureException e) {
+            throw new InvalidTokenException();
         }
     }
 

--- a/src/main/java/com/econo_4factorial/newproject/auth/service/OAuthService.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/service/OAuthService.java
@@ -1,31 +1,51 @@
-package com.econo_4factorial.newproject.auth.service;
+    package com.econo_4factorial.newproject.auth.service;
 
-import com.econo_4factorial.newproject.auth.dto.Res.LoginRes;
-import com.econo_4factorial.newproject.auth.service.kakao.KaKaoOAuthService;
-import com.econo_4factorial.newproject.user.domain.User;
-import com.econo_4factorial.newproject.user.dto.UserInfoDTO;
-import com.econo_4factorial.newproject.user.service.UserService;
-import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+    import com.econo_4factorial.newproject.auth.dto.Req.AppleLoginReq;
+    import com.econo_4factorial.newproject.auth.dto.apple.AppleUserInfoDTO;
+    import com.econo_4factorial.newproject.auth.dto.kakao.KakaoUserInfoDTO;
+    import com.econo_4factorial.newproject.auth.exception.BadRequestException.AuthException;
+    import com.econo_4factorial.newproject.auth.jwt.AuthToken;
+    import com.econo_4factorial.newproject.auth.jwt.service.AuthTokenService;
+    import com.econo_4factorial.newproject.auth.service.apple.AppleOAuthService;
+    import com.econo_4factorial.newproject.auth.service.kakao.KaKaoOAuthService;
+    import com.econo_4factorial.newproject.common.exception.BadRequestException;
+    import com.econo_4factorial.newproject.user.domain.User;
+    import com.econo_4factorial.newproject.user.service.UserService;
+    import lombok.RequiredArgsConstructor;
+    import org.springframework.stereotype.Service;
+    import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@AllArgsConstructor
-public class OAuthService {
-    private final UserService userService;
-    private final KaKaoOAuthService kaKaoOAuthService;
+    @Service
+    @RequiredArgsConstructor
+    public class OAuthService {
+        private final UserService userService;
+        private final KaKaoOAuthService kaKaoOAuthService;
+        private final AppleOAuthService appleOAuthService;
+        private final AuthTokenService authTokenService;
 
-    public String getKakaoLoginURI () {
-        return kaKaoOAuthService.getLoginURI();
+        public String getKakaoLoginURI () {
+            return kaKaoOAuthService.getLoginURI();
+        }
+
+        @Transactional
+        public AuthToken loginWithKaKao (String kakaoAuthorizationCode) {
+            try {
+                KakaoUserInfoDTO userInfo = kaKaoOAuthService.getUserInfo(kakaoAuthorizationCode);
+                User loginUser = userService.findOrCreateUserByKakaoUserInfo(userInfo);
+                return authTokenService.issueAuthToken(loginUser.getId());
+            } catch (BadRequestException e) {
+                throw new AuthException();
+            }
+        }
+
+        @Transactional
+        public AuthToken loginWithApple (AppleLoginReq appleLoginReq) {
+            try {
+                AppleUserInfoDTO userInfo =appleOAuthService.getUserInfo(appleLoginReq);
+                User loginUser = userService.findOrCreateUserByAppleUserInfo(userInfo);
+                return authTokenService.issueAuthToken(loginUser.getId());
+            } catch (BadRequestException e) {
+                throw new AuthException();
+            }
+        }
     }
-
-    @Transactional
-    public LoginRes loginWithKaKao (String kakaoAuthorizationCode) {
-        UserInfoDTO userInfo = kaKaoOAuthService.getUserInfo(kakaoAuthorizationCode);
-        User loginUser = userService.findOrCreateUserByUserInfo(userInfo);
-        // jwt 토큰 발급 코드
-        //발급된 jwt 토큰 redis에 저장 코드
-        return new LoginRes("temp", "temp"); //추후 수정 필요
-    }
-
-}

--- a/src/main/java/com/econo_4factorial/newproject/auth/service/apple/AppleJwtHandler.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/service/apple/AppleJwtHandler.java
@@ -1,0 +1,53 @@
+package com.econo_4factorial.newproject.auth.service.apple;
+
+import com.econo_4factorial.newproject.auth.exception.BadRequestException.ExpiredTokenException;
+import com.econo_4factorial.newproject.auth.exception.InternalServerException.AppleTokenHeaderParsingException;
+import com.econo_4factorial.newproject.auth.exception.BadRequestException.InvalidTokenException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AppleJwtHandler {
+    public Map<String, String> parseHeaders(String token) {
+        try {
+            String header = token.split("\\.")[0]; //정규식을 활용해서 header만 추출
+            return new ObjectMapper().readValue(decodeHeader(header), Map.class);
+        }catch (JsonProcessingException e) {
+            throw new AppleTokenHeaderParsingException();
+        }
+    }
+
+    private String decodeHeader(String header) {
+        return new String(
+                Base64.getDecoder().decode(header),
+                StandardCharsets.UTF_8
+        );
+    }
+
+    public Claims getTokenClaims(String token, PublicKey key) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (SignatureException | MalformedJwtException e) {
+            throw new InvalidTokenException();
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException();
+        }
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/service/apple/AppleOAuthFeignClient.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/service/apple/AppleOAuthFeignClient.java
@@ -1,0 +1,11 @@
+package com.econo_4factorial.newproject.auth.service.apple;
+
+import com.econo_4factorial.newproject.auth.dto.apple.ApplePublicKeysResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name="appleOAuthFeinghClient", url ="https://appleid.apple.com/auth")
+public interface AppleOAuthFeignClient {
+    @GetMapping("/keys")
+    ApplePublicKeysResponse getApplePublicKeys ();
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/service/apple/AppleOAuthService.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/service/apple/AppleOAuthService.java
@@ -1,0 +1,55 @@
+package com.econo_4factorial.newproject.auth.service.apple;
+
+import com.econo_4factorial.newproject.auth.dto.Req.AppleLoginReq;
+import com.econo_4factorial.newproject.auth.dto.apple.ApplePublicKeysResponse;
+import com.econo_4factorial.newproject.auth.dto.apple.AppleUserInfoDTO;
+import com.econo_4factorial.newproject.auth.exception.InternalServerException.InvalidAudienceException;
+import com.econo_4factorial.newproject.auth.exception.InternalServerException.NotAppleIssuerException;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+
+@Service
+@RequiredArgsConstructor
+public class AppleOAuthService {
+    private final AppleOAuthFeignClient appleOAuthFeignClient;
+    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    private final AppleJwtHandler AppleJwtHandler;
+
+    @Value("${oauth.apple.iss}")
+    private String iss;
+
+    @Value("${oauth.apple.client-id}")
+    private String client_id;
+
+    public AppleUserInfoDTO getUserInfo(AppleLoginReq appleLoginReq) {
+        Map<String, String> headers = AppleJwtHandler.parseHeaders(appleLoginReq.identityToken()); //identityToken 헤더 파싱
+        ApplePublicKeysResponse applePublicKeys = appleOAuthFeignClient.getApplePublicKeys(); //애플 공개키 데이터 가져오기
+        PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(applePublicKeys, headers); //identityToken 서명 검증에서 쓰이는 공개키 생성
+        Claims tokenClaims = AppleJwtHandler.getTokenClaims(appleLoginReq.identityToken(), publicKey); // 토큰에서 들어있는 claim 값 가져오기
+        validateClaims(tokenClaims); // identityToken 검증
+        return appleLoginReq.toAppleUserInfoDTO(tokenClaims.getSubject());
+    }
+
+    private void validateClaims(Claims tokenClaims) {
+        isAppleIssuer(tokenClaims);
+        isOurServiceAudience(tokenClaims);
+    }
+
+    private void isAppleIssuer(Claims tokenClaims) {
+        if (!iss.equals(tokenClaims.getIssuer()))
+            throw new NotAppleIssuerException();
+    }
+
+    private void isOurServiceAudience(Claims tokenClaims) {
+        if (client_id.equals(tokenClaims.getAudience()))
+            throw new InvalidAudienceException();
+    }
+
+
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/service/apple/ApplePublicKeyGenerator.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/service/apple/ApplePublicKeyGenerator.java
@@ -1,0 +1,46 @@
+package com.econo_4factorial.newproject.auth.service.apple;
+
+import com.econo_4factorial.newproject.auth.dto.apple.ApplePublicKeysResponse;
+import com.econo_4factorial.newproject.auth.dto.apple.ApplePublicKeysResponse.*;
+import com.econo_4factorial.newproject.auth.exception.InternalServerException.ApplePublicKeyGenerateException;
+import com.econo_4factorial.newproject.auth.exception.InternalServerException.NotMatchedApplePublicKeyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class ApplePublicKeyGenerator {
+    public PublicKey generatePublicKey(ApplePublicKeysResponse applePublicKeys, Map<String, String> headers) {
+        ApplePublicKey matchedKey = applePublicKeys.keys().stream()
+                .filter(key -> key.kid().equals(headers.get("kid")) && key.alg().equals(headers.get("alg")))
+                .findAny()
+                .orElseThrow(() -> new NotMatchedApplePublicKeyException());
+        return generateKey(matchedKey);
+    }
+
+    private PublicKey generateKey (ApplePublicKey publicKey) {
+        try {
+            byte[] nBytes = Base64.getUrlDecoder().decode(publicKey.n());
+            byte[] eBytes = Base64.getUrlDecoder().decode(publicKey.e());
+            RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(
+                    new BigInteger(1, nBytes),
+                    new BigInteger(1, eBytes)
+            );
+            KeyFactory keyFactory = KeyFactory.getInstance(publicKey.kty());
+            return keyFactory.generatePublic(publicKeySpec);
+        }catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new ApplePublicKeyGenerateException();
+        }
+    }
+
+
+}

--- a/src/main/java/com/econo_4factorial/newproject/common/annotation/ValidEmailPattern.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/annotation/ValidEmailPattern.java
@@ -1,0 +1,19 @@
+package com.econo_4factorial.newproject.common.annotation;
+
+import com.econo_4factorial.newproject.common.annotation.validator.ValidEmailPatternValidator;
+import com.econo_4factorial.newproject.common.exception.ValidationMessage;
+import jakarta.validation.Constraint;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidEmailPatternValidator.class)
+public @interface ValidEmailPattern {
+    String message() default ValidationMessage.EMAIL_INVALID_PATTERN;
+    Class[] groups() default {};
+    Class[] payload() default {};
+}

--- a/src/main/java/com/econo_4factorial/newproject/common/annotation/validator/ValidEmailPatternValidator.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/annotation/validator/ValidEmailPatternValidator.java
@@ -1,0 +1,16 @@
+package com.econo_4factorial.newproject.common.annotation.validator;
+
+import com.econo_4factorial.newproject.common.annotation.ValidEmailPattern;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.regex.Pattern;
+
+public class ValidEmailPatternValidator implements ConstraintValidator<ValidEmailPattern, String> {
+    private static final Pattern VALID_EMAIL_PATTERN = Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,3}$");
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return VALID_EMAIL_PATTERN.matcher(value).matches();
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
@@ -1,0 +1,9 @@
+package com.econo_4factorial.newproject.common.exception;
+
+public class ValidationMessage {
+    public static final String IDENTITY_TOKEN_REQUIRED = "identityToken이 누락되었습니다";
+    public static final String FAMILY_NAME_REQUIRED = "familyName이 누락되었습니다";
+    public static final String GIVEN_NAME_REQUIRED = "givenName이 누락되었습니다";
+    public static final String EMAIL_INVALID_PATTERN = "email이 올바르지 않은 패턴입니다";
+    public static final String REFRESH_TOKEN_REQUIRED = "refreshToken이 누락되었습니다";
+}

--- a/src/main/java/com/econo_4factorial/newproject/common/util/HttpHeadersGenerator.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/util/HttpHeadersGenerator.java
@@ -1,0 +1,16 @@
+package com.econo_4factorial.newproject.common.util;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.http.HttpHeaders;
+
+import java.net.URI;
+
+@UtilityClass
+public class HttpHeadersGenerator {
+
+    public static HttpHeaders setLocation(String uri) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(URI.create(uri));
+        return headers;
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/common/util/RedirectUriBuilder.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/util/RedirectUriBuilder.java
@@ -1,0 +1,26 @@
+package com.econo_4factorial.newproject.common.util;
+
+
+import com.econo_4factorial.newproject.auth.jwt.AuthToken;
+import lombok.experimental.UtilityClass;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@UtilityClass
+public class RedirectUriBuilder {
+    private final String baseUri = "http://soop.euichan.com/social-login-loading";
+
+    public String buildLoginSuccessUri (AuthToken authToken) {
+        return UriComponentsBuilder.fromUriString(baseUri)
+                .queryParam("accessToken", authToken.accessToken())
+                .queryParam("refreshToken", authToken.refreshToken())
+                .queryParam("expiredTime", authToken.expirationTime())
+                .build()
+                .toUriString();
+    }
+
+    public String buildLoginFailUri () {
+        return UriComponentsBuilder.fromUriString(baseUri)
+                .build()
+                .toUriString();
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -20,12 +20,25 @@ public class User extends BaseEntity {
     @AttributeOverrides({
             @AttributeOverride(name = "email", column = @Column(name = "email", nullable = false, unique = true)),
             @AttributeOverride(name = "name", column = @Column(name = "name", nullable=false)),
-            @AttributeOverride(name = "phoneNumber", column = @Column(name = "phone_number", nullable = false))
+            @AttributeOverride(name = "phoneNumber", column = @Column(name = "phone_number"))
     })
     private UserInfo userInfo;
 
-    @Builder
-    public User(String email, String name, String phoneNumber) {
-        this.userInfo = new UserInfo(email, name, phoneNumber);
+    @Column(unique = true)
+    private Long kakaoId;
+
+    @Column(unique = true)
+    private String appleSub;
+
+    @Builder(builderMethodName = "kakaoUserBuilder", builderClassName = "kakaoUserBuilder")
+    public User(String email, String name, Long kakaoId) {
+        this.userInfo = new UserInfo(email, name);
+        this.kakaoId = kakaoId;
+    }
+
+    @Builder(builderMethodName = "appleUserBuilder", builderClassName = "appleUserBuilder")
+    public User(String email, String name, String appleSub) {
+        this.userInfo = new UserInfo(email, name);
+        this.appleSub = appleSub;
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/vo/UserInfo.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/vo/UserInfo.java
@@ -24,13 +24,12 @@ public class UserInfo {
 
     private String phoneNumber;
 
-    public UserInfo(String email, String name, String phoneNumber){
+    public UserInfo(String email, String name){
         validateEmail(email);
         validateName(name);
-        validatePhoneNumber(phoneNumber);
         this.email = email;
         this.name = name;
-        this.phoneNumber = phoneNumber;
+        this.phoneNumber = null;
     }
 
     private void validateEmail(String email) {

--- a/src/main/java/com/econo_4factorial/newproject/user/exeception/BadRequestException/UserNotFoundException.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/exeception/BadRequestException/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package com.econo_4factorial.newproject.user.exeception.BadRequestException;
+
+import com.econo_4factorial.newproject.common.exception.BadRequestException;
+import com.econo_4factorial.newproject.user.exeception.UserErrorType;
+
+public class UserNotFoundException extends BadRequestException {
+    public UserNotFoundException () {
+        super(UserErrorType.USER_NOT_FOUND_EXCEPTION);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/exeception/UserErrorType.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/exeception/UserErrorType.java
@@ -1,0 +1,33 @@
+package com.econo_4factorial.newproject.user.exeception;
+
+import com.econo_4factorial.newproject.common.exception.ErrorType;
+import org.springframework.http.HttpStatus;
+
+public enum UserErrorType implements ErrorType {
+    USER_NOT_FOUND_EXCEPTION ("User400_001", HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다");
+
+    private final String errorCode;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    UserErrorType(String errorCode, HttpStatus httpStatus, String message) {
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/mapper/UserMapper.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/mapper/UserMapper.java
@@ -1,17 +1,26 @@
 package com.econo_4factorial.newproject.user.mapper;
 
+import com.econo_4factorial.newproject.auth.dto.apple.AppleUserInfoDTO;
+import com.econo_4factorial.newproject.auth.dto.kakao.KakaoUserInfoDTO;
 import com.econo_4factorial.newproject.user.domain.User;
-import com.econo_4factorial.newproject.user.dto.UserInfoDTO;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public final class UserMapper {
-    public static User toEntity (UserInfoDTO userInfoDTO) {
-        return User.builder()
+    public static User toEntity (KakaoUserInfoDTO userInfoDTO) {
+        return User.kakaoUserBuilder()
+                .kakaoId(userInfoDTO.kakaoId())
                 .email(userInfoDTO.email())
                 .name(userInfoDTO.name())
-                .phoneNumber(userInfoDTO.phoneNumber())
+                .build();
+    }
+
+    public static User toEntity (AppleUserInfoDTO userInfoDTO) {
+        return User.appleUserBuilder()
+                .appleSub(userInfoDTO.appleSub())
+                .email(userInfoDTO.email())
+                .name(userInfoDTO.name())
                 .build();
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/repository/UserRepository.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/repository/UserRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByUserInfo_NameAndUserInfo_PhoneNumber(String name, String phoneNumber);
+    Optional<User> findByKakaoId(Long kakaoId);
+
+    Optional<User> findByAppleSub(String appleSub);
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -1,7 +1,9 @@
 package com.econo_4factorial.newproject.user.service;
 
+import com.econo_4factorial.newproject.auth.dto.apple.AppleUserInfoDTO;
+import com.econo_4factorial.newproject.auth.dto.kakao.KakaoUserInfoDTO;
 import com.econo_4factorial.newproject.user.domain.User;
-import com.econo_4factorial.newproject.user.dto.UserInfoDTO;
+import com.econo_4factorial.newproject.user.exeception.BadRequestException.UserNotFoundException;
 import com.econo_4factorial.newproject.user.repository.UserRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,16 +15,29 @@ import static com.econo_4factorial.newproject.user.mapper.UserMapper.toEntity;
 @AllArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
-
-    @Transactional
-    public User findOrCreateUserByUserInfo(UserInfoDTO userInfoDTO) {
-        return userRepository.findByUserInfo_NameAndUserInfo_PhoneNumber(userInfoDTO.name(), userInfoDTO.phoneNumber())
-                .orElseGet(()-> addUser(userInfoDTO));
+    @Transactional(readOnly = true)
+    public User findUserByIdOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
     }
 
-    private User addUser(UserInfoDTO userInfoDTO) {
+    @Transactional
+    public User findOrCreateUserByKakaoUserInfo(KakaoUserInfoDTO userInfoDTO) {
+        return userRepository.findByKakaoId(userInfoDTO.kakaoId())
+                .orElseGet(()-> addKakaoUser(userInfoDTO));
+    }
+
+    private User addKakaoUser(KakaoUserInfoDTO userInfoDTO) {
         return userRepository.save(toEntity(userInfoDTO));
     }
 
+    @Transactional
+    public User findOrCreateUserByAppleUserInfo(AppleUserInfoDTO userInfo) {
+        return userRepository.findByAppleSub(userInfo.appleSub())
+                .orElseGet(() -> addAppleUser(userInfo));
+    }
 
+    private User addAppleUser(AppleUserInfoDTO userInfo) {
+        return userRepository.save(toEntity(userInfo));
+    }
 }

--- a/src/main/resources/application-apple.yml
+++ b/src/main/resources/application-apple.yml
@@ -1,0 +1,11 @@
+spring:
+  config:
+    activate:
+      on-profile: apple
+
+oauth:
+  apple:
+    client-id: ${APPLE_CLIENT_ID}
+    iss: ${APPLE_ISS}
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,13 +2,16 @@ spring:
   application:
     name: NewProject
   config:
-    import: optional:file:.env[.properties], optional:file:metrics.yml
-  jackson:
-    property-naming-strategy: SNAKE_CASE
-
+    import: optional:file:.env[.properties]
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
   profiles:
     group:
       local:
         - jpa
         - token
         - kakao
+        - apple


### PR DESCRIPTION
## #️⃣연관된 이슈

#22 

## 📝작업 내용

- 애플 로그인 기능 API 구현
- 애플 공개키 데이터조회 HttpClient 구현
- 받아온 공개키 데이터를 통한 공개키 생성 구현
- 애플이 발급한 identityToken에 대한 서명 검증 구현
- 애플 사용자 등록 구현
- AuthErrorType 및 UserErrorType 정의
- RedirectUriBuilder 및 HttpHeadersGenerator 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
애플 로그인에 대해서 부가적인 설명을 드리자면 아래와 같이 이루어집니다
1. 클라이언트가 애플로부터 받아온 email, name, identityToken을 받는다
2. 애플이 발급한 JWT 토큰인 identityToken을 복호화 하기 위해서 애플로부터 공개키 데이터 정보를 받아온다. 이 때 공개키 2개에 대한 정보를 받아온다
3. identityToken의 header만 추출하고, Base64로 인코딩 되어있는 것을 디코딩하여 identityToken을 복호화 할 때 필요한 공개키가 정보를 얻는다 
4. 3번에서 얻은 공개키 정보를 바탕으로 2번에서 받아온 두 공개키 중에서 매칭되는 공개키를 찾는다
5. 공개키 데이터를 바탕으로 공개키를 실제로 생성한다
6. 생성된 공개키를 바탕으로 복호화하여 identityToken을 apple이 발급했는지 확인(서명 검증) 한다
7. 검증이 완료됐으면, identityToken의 sub(애플이 제공하는 사용자 식별자), email, name을 바탕으로 우리 서비스에 사용자를 등록한다

PR이 좀 큰데 리뷰 잘 부탁드리겠습니다!
메소드명이나, 책임 분리 관점에서 괜찮은지 봐주세요~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 애플 소셜 로그인(Apple OAuth) 연동 및 인증 플로우가 추가되었습니다.
  - 카카오 및 애플 로그인 시 리다이렉트 방식이 개선되어, 인증 성공 시 토큰과 함께 지정된 URI로 이동합니다.
  - 이메일 형식 검증 등 입력값 유효성 검사가 강화되었습니다.

- **버그 수정**
  - JWT 토큰 만료 및 서명 오류에 대해 더 명확한 예외 처리가 적용되었습니다.

- **리팩터링**
  - 사용자 정보 저장 방식이 소셜 로그인 ID 기반으로 변경되었습니다.
  - 사용자 조회 및 생성 로직이 카카오/애플 계정에 맞게 분리되었습니다.

- **환경설정**
  - Redis 연결 정보 및 애플 OAuth 설정이 환경 변수로 관리됩니다.
  - Jackson 네이밍 전략 관련 설정이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->