### PR TITLE
[BE-6] feat: 일관된 응답을 위한 ApiResponse 구현 

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/common/util/api/ApiResponse.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/util/api/ApiResponse.java
@@ -1,0 +1,31 @@
+package com.econo_4factorial.newproject.common.util.api;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+@UtilityClass
+public class ApiResponse {
+    private static final String SUCCESS = "success";
+    private static final String ERROR = "error";
+
+    public static <D> ApiResult<ApiResult.SuccessBody<Void>> success(final HttpStatus status) {
+        return new ApiResult<>(new ApiResult.SuccessBody<>(null, SUCCESS), status);
+    }
+
+    public static <D> ApiResult<ApiResult.SuccessBody<D>> success(final D data, final HttpStatus status) {
+        return new ApiResult<>(new ApiResult.SuccessBody<>(data, SUCCESS), status);
+    }
+
+    public static ApiResult<ApiResult.SuccessBody<Void>> success(final HttpHeaders headers, final HttpStatus status) {
+        return new ApiResult<>(new ApiResult.SuccessBody<Void>(null, SUCCESS ), headers, status);
+    }
+
+    public static ApiResult<ApiResult.ErrorBody> fail (final String errorCode, final String message, final HttpStatus status) {
+        return new ApiResult<>(new ApiResult.ErrorBody(ERROR, errorCode, message), status);
+    }
+
+    public static ApiResult<ApiResult.ErrorBody> fail(final String errorCode, final String message, final HttpHeaders headers, HttpStatus status) {
+        return new ApiResult<>(new ApiResult.ErrorBody(ERROR, errorCode, message), headers, status);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/common/util/api/ApiResponse.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/util/api/ApiResponse.java
@@ -9,7 +9,7 @@ public class ApiResponse {
     private static final String SUCCESS = "success";
     private static final String ERROR = "error";
 
-    public static <D> ApiResult<ApiResult.SuccessBody<Void>> success(final HttpStatus status) {
+    public static ApiResult<ApiResult.SuccessBody<Void>> success(final HttpStatus status) {
         return new ApiResult<>(new ApiResult.SuccessBody<>(null, SUCCESS), status);
     }
 

--- a/src/main/java/com/econo_4factorial/newproject/common/util/api/ApiResult.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/util/api/ApiResult.java
@@ -1,0 +1,34 @@
+package com.econo_4factorial.newproject.common.util.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.io.Serializable;
+
+public class ApiResult<B> extends ResponseEntity<B> {
+    public ApiResult(B body, HttpStatus status) {
+        super(body, status);
+    }
+
+    public ApiResult(B body, HttpHeaders headers, HttpStatus status) {
+        super (headers, status);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class SuccessBody<D> implements Serializable {
+        private D data;
+        private String status; //HttpStatus가 아닌 success를 의미하는 status임
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ErrorBody implements Serializable {
+        private String status; //HttpStatus가 아닌 fail를 의미하는 status임
+        private String errorCode;
+        private String message;
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/common/util/api/ApiResult.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/util/api/ApiResult.java
@@ -14,7 +14,7 @@ public class ApiResult<B> extends ResponseEntity<B> {
     }
 
     public ApiResult(B body, HttpHeaders headers, HttpStatus status) {
-        super (headers, status);
+        super (body, headers, status);
     }
 
     @Getter


### PR DESCRIPTION
## #️⃣연관된 이슈

#24 

## 📝작업 내용

- ApiResponse 구현
- 응답 Body에 들어가는 구조 정의

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
네이밍 괜찮은지 한번 봐주세요! AuthController에서 응답할 때 헷갈리지 않을지 의견 부탁드려요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - API 응답을 표준화하는 새로운 응답 포맷이 도입되었습니다. 성공 및 실패 응답이 일관된 구조로 제공됩니다.
    - API 응답에서 성공과 오류 메시지, 상태, 데이터, 에러 코드 등을 명확하게 구분하여 전달합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->