### PR TITLE
[BE-8] refactor: 카카오 로그인 요청 시 리다이렉트가 아닌 주소 반환

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
@@ -1,5 +1,6 @@
 package com.econo_4factorial.newproject.auth.controller;
 
+import com.econo_4factorial.newproject.auth.dto.Res.KakaoUriRes;
 import com.econo_4factorial.newproject.auth.dto.Req.AppleLoginReq;
 import com.econo_4factorial.newproject.auth.jwt.AuthToken;
 import com.econo_4factorial.newproject.auth.service.OAuthService;
@@ -19,10 +20,10 @@ import org.springframework.web.bind.annotation.*;
 public class OAuthController {
     private final OAuthService oAuthService;
 
-    @PostMapping("/kakao/login")
-    public ApiResult<ApiResult.SuccessBody<Void>> getKakaoLoginUri() {
-        HttpHeaders headers = HttpHeadersGenerator.setLocation(oAuthService.getKakaoLoginURI());
-        return ApiResponse.success(headers, HttpStatus.FOUND);
+    @GetMapping("/kakao/login")
+    public ApiResult<ApiResult.SuccessBody<KakaoUriRes>> getKakaoLoginUri() {
+        String uri = oAuthService.getKakaoLoginURI();
+        return ApiResponse.success(new KakaoUriRes(uri), HttpStatus.OK);
     }
 
     @GetMapping("/kakao/callback")

--- a/src/main/java/com/econo_4factorial/newproject/auth/dto/KakaoUriRes.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/dto/KakaoUriRes.java
@@ -1,0 +1,6 @@
+package com.econo_4factorial.newproject.auth.dto;
+
+public record KakaoUriRes (
+        String uri
+) {
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/dto/Res/KakaoUriRes.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/dto/Res/KakaoUriRes.java
@@ -1,4 +1,4 @@
-package com.econo_4factorial.newproject.auth.dto;
+package com.econo_4factorial.newproject.auth.dto.Res;
 
 public record KakaoUriRes (
         String uri


### PR DESCRIPTION
## #️⃣연관된 이슈

#27 

## 📝작업 내용

> 카카오 로그인 요청 시 로그인 uri에 리다이렉트 시키는 것이 아닌 로그인 uri를 응답 body에 담아서 응답하도록 리팩터링

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 카카오 로그인 URI를 JSON 형태로 반환하는 기능이 추가되었습니다.

- **변경 사항**
  - 카카오 로그인 요청 방식이 POST에서 GET으로 변경되었습니다.
  - 카카오 로그인 요청 시 302 리다이렉트 대신 200 OK와 함께 URI 정보를 포함한 JSON 응답을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->