### PR TITLE
[BE-10] refactor: 유효하지 않은 토큰, 발급하지 않은 토큰 에러 응답에 대한 Http 상태 코드 리팩터링

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/auth/exception/AuthErrorType.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/exception/AuthErrorType.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum AuthErrorType implements ErrorType {
     AUTH_EXCEPTION ("Auth400_001", HttpStatus.FOUND, "로그인 과정 중 에러가 발생했습니다"),
-    INVALID_TOKEN_EXCEPTION("Auth401_001", HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다"),
-    EXPIRED_TOKEN_EXCEPTION("Auth401_002", HttpStatus.BAD_REQUEST, "만료된 토큰입니다"),
+    INVALID_TOKEN_EXCEPTION("Auth401_001", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+    EXPIRED_TOKEN_EXCEPTION("Auth401_002", HttpStatus.UNAUTHORIZED, "만료된 토큰입니다"),
 
     APPLE_TOKEN_HEADER_PARSING_EXCEPTION("Auth500_001", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken헤더 파싱 중 에러가 발생했습니다"),
     NOT_MATCHED_APPLE_PUBLIC_KEY_EXCEPTION("Auth500_002", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken의 서명(signature) 검증 중 매칭되는 공개키를 찾을 수 없습니다"),


### PR DESCRIPTION
## #️⃣연관된 이슈

#29 

## 📝작업 내용

유효하지 않은 토큰, 발급하지 않은 토큰 에러 응답에 대한 Http 상태 코드값을 401로 리팩터링

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
상태 코드 값만 바꾼거라 바로 머지시켜도 될 것 같습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 잘못된 토큰 또는 만료된 토큰 사용 시 반환되는 HTTP 상태 코드가 400(Bad Request)에서 401(Unauthorized)로 변경되어, 인증 오류가 더 정확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->