### PR TITLE
[BE-9] refactor: ErrorCode 네이밍 리팩터링

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/auth/exception/AuthErrorType.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/exception/AuthErrorType.java
@@ -4,15 +4,15 @@ import com.econo_4factorial.newproject.common.exception.ErrorType;
 import org.springframework.http.HttpStatus;
 
 public enum AuthErrorType implements ErrorType {
-    AUTH_EXCEPTION ("Auth400_001", HttpStatus.FOUND, "로그인 과정 중 에러가 발생했습니다"),
-    INVALID_TOKEN_EXCEPTION("Auth401_001", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
-    EXPIRED_TOKEN_EXCEPTION("Auth401_002", HttpStatus.UNAUTHORIZED, "만료된 토큰입니다"),
+    AUTH_EXCEPTION ("AUTH400_001", HttpStatus.FOUND, "로그인 과정 중 에러가 발생했습니다"),
+    INVALID_TOKEN_EXCEPTION("AUTH401_001", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+    EXPIRED_TOKEN_EXCEPTION("AUTH401_002", HttpStatus.UNAUTHORIZED, "만료된 토큰입니다"),
 
-    APPLE_TOKEN_HEADER_PARSING_EXCEPTION("Auth500_001", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken헤더 파싱 중 에러가 발생했습니다"),
-    NOT_MATCHED_APPLE_PUBLIC_KEY_EXCEPTION("Auth500_002", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken의 서명(signature) 검증 중 매칭되는 공개키를 찾을 수 없습니다"),
-    APPLE_PUBLIC_KEY_GENERATE_EXCEPTION ("Auth500_003", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken의 서명(signature) 검증에서 사용되는 공개키 생성 중 에러가 발생했습니다"),
-    NOT_APPLE_ISSUER_EXCEPTION("Auth500_004", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken 검증 중 issuer가 애플이 아닙니다"),
-    INVALID_AUDIENCE_EXCEPTION("Auth500_005", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken 검증 중 audience가 client_id가 아닙니다");
+    APPLE_TOKEN_HEADER_PARSING_EXCEPTION("AUTH500_001", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken헤더 파싱 중 에러가 발생했습니다"),
+    NOT_MATCHED_APPLE_PUBLIC_KEY_EXCEPTION("AUTH500_002", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken의 서명(signature) 검증 중 매칭되는 공개키를 찾을 수 없습니다"),
+    APPLE_PUBLIC_KEY_GENERATE_EXCEPTION ("AUTH500_003", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken의 서명(signature) 검증에서 사용되는 공개키 생성 중 에러가 발생했습니다"),
+    NOT_APPLE_ISSUER_EXCEPTION("AUTH500_004", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken 검증 중 issuer가 애플이 아닙니다"),
+    INVALID_AUDIENCE_EXCEPTION("AUTH500_005", HttpStatus.INTERNAL_SERVER_ERROR, "애플 identityToken 검증 중 audience가 client_id가 아닙니다");
 
     private final String errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/econo_4factorial/newproject/common/exception/CommonErrorType.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/exception/CommonErrorType.java
@@ -3,10 +3,10 @@ package com.econo_4factorial.newproject.common.exception;
 import org.springframework.http.HttpStatus;
 
 public enum CommonErrorType implements ErrorType{
-    METHOD_ARGUMENT_NOT_VALID_EXCEPTION("Common400_001", HttpStatus.BAD_REQUEST, ""),
-    ILLEGAL_ARGUMENT_EXCEPTION("Common400_002", HttpStatus.BAD_REQUEST, "Illegal argument exception 발생 "),
-    MISSING_PATH_VARIABLE_EXCEPTION("Common400_003", HttpStatus.BAD_REQUEST, "경로 변수(PathVariable)가 누락됐습니다."),
-    MISSING_REQUEST_PARAM_EXCEPTION("Common400_004", HttpStatus.BAD_REQUEST, "쿼리 스트링이 누락됐습니다.");
+    METHOD_ARGUMENT_NOT_VALID_EXCEPTION("COMMON400_001", HttpStatus.BAD_REQUEST, ""),
+    ILLEGAL_ARGUMENT_EXCEPTION("COMMON400_002", HttpStatus.BAD_REQUEST, "Illegal argument exception 발생 "),
+    MISSING_PATH_VARIABLE_EXCEPTION("COMMON400_003", HttpStatus.BAD_REQUEST, "경로 변수(PathVariable)가 누락됐습니다."),
+    MISSING_REQUEST_PARAM_EXCEPTION("COMMON400_004", HttpStatus.BAD_REQUEST, "쿼리 스트링이 누락됐습니다.");
 
     private final String errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/econo_4factorial/newproject/user/exeception/UserErrorType.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/exeception/UserErrorType.java
@@ -4,7 +4,7 @@ import com.econo_4factorial.newproject.common.exception.ErrorType;
 import org.springframework.http.HttpStatus;
 
 public enum UserErrorType implements ErrorType {
-    USER_NOT_FOUND_EXCEPTION ("User400_001", HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다");
+    USER_NOT_FOUND_EXCEPTION ("USER400_001", HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다");
 
     private final String errorCode;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈

#28 

## 📝작업 내용

- ErrorCode에서 앞부분 문자열을 모두 대문자로 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

단순히 대문자로 치환만 했기에 딱히 리뷰할 게 없습니다 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 오류 코드의 접두사가 모두 대문자로 변경되어 일관성이 향상되었습니다. (예: "Auth400_001" → "AUTH400_001", "Common400_001" → "COMMON400_001", "User400_001" → "USER400_001")

<!-- end of auto-generated comment: release notes by coderabbit.ai -->