### PR TITLE
[infra-2] setting: redis properties 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
+      ssl:
+        enabled: true
   profiles:
     group:
       local:


### PR DESCRIPTION
## #️⃣연관된 이슈

#36 

## 📝작업 내용

> 
redis ssl enabled : true 추가
aws에서 valkey cluster를 사용할 경우 반드시 ssl enable을 해줘야함.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/17c04892-0d7d-4689-b12e-2cddd02d6127)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Redis 연결에 SSL이 활성화되어 보안 통신이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->