### PR TITLE
[refactor]: Dockerfile 캐싱 사용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-# Build Stage
 FROM gradle:7.6.2-jdk17 AS build
-WORKDIR /app
-COPY --chown=gradle:gradle . .
-RUN gradle build -x test
 
-# Run Stage
+WORKDIR /app
+COPY --chown=gradle:gradle build.gradle.kts settings.gradle.kts gradle.properties ./
+COPY --chown=gradle:gradle gradle ./gradle
+RUN gradle dependencies --no-daemon || true
+COPY --chown=gradle:gradle . .
+RUN gradle build -x test --no-daemon
+
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
+
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
## #️⃣연관된 이슈

#48 

## 📝작업 내용

Dockerfile에서 캐싱된 레이어를 사용하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Docker 이미지 빌드 프로세스가 개선되어, Gradle 의존성 사전 다운로드 및 빌드 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->