### PR TITLE
[BE-20] bug: redis에 연결하지 못하는 에러

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/common/config/RedisConfig.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/config/RedisConfig.java
@@ -5,7 +5,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import java.time.Duration;
 
 @Configuration
 public class RedisConfig {
@@ -21,6 +24,10 @@ public class RedisConfig {
         RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
         redisConfiguration.setHostName(host);
         redisConfiguration.setPort(port);
-        return new LettuceConnectionFactory(redisConfiguration);
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .commandTimeout(Duration.ofSeconds(5))
+                .useSsl()
+                .build();
+        return new LettuceConnectionFactory(redisConfiguration, clientConfig);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #60 

## 📝작업 내용

> elascticache redis 클러스터에 연결하기 위해서는 ssl 설정이 필수로 요구됩니다.
RedisConfig에 ssl 설정을 추가하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * Redis 연결 시 명령어 타임아웃(5초) 및 SSL 지원이 추가되어 보안성과 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->