### PR TITLE
[BE-26] style: UnExpectedException 에 대한 에러코드명 대문자로 수정

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/common/exception/CommonErrorType.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/exception/CommonErrorType.java
@@ -9,7 +9,7 @@ public enum CommonErrorType implements ErrorType{
     MISSING_PATH_VARIABLE_EXCEPTION("COMMON400_003", HttpStatus.BAD_REQUEST, "경로 변수(PathVariable)가 누락됐습니다."),
     MISSING_REQUEST_PARAM_EXCEPTION("COMMON400_004", HttpStatus.BAD_REQUEST, "쿼리 스트링이 누락됐습니다."),
   
-    UN_EXPECTED_EXCEPTION("Common500_001", HttpStatus.INTERNAL_SERVER_ERROR, "예기치 못한 에러가 발생했습니다.");
+    UN_EXPECTED_EXCEPTION("COMMON500_001", HttpStatus.INTERNAL_SERVER_ERROR, "예기치 못한 에러가 발생했습니다.");
 
     private final String errorCode;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈

#73 

## 📝작업 내용

- `UnExpectedException` 의 에러코드명 대문자로 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 오류 코드의 대소문자 표기를 일관성 있게 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->