### PR TITLE
[BE-29] refactor: 북마크 등록 API의 courseId 전달 방식 변경

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
@@ -6,4 +6,6 @@ public class ValidationMessage {
     public static final String GIVEN_NAME_REQUIRED = "givenName이 누락되었습니다";
     public static final String EMAIL_INVALID_PATTERN = "email이 올바르지 않은 패턴입니다";
     public static final String REFRESH_TOKEN_REQUIRED = "refreshToken이 누락되었습니다";
+    public static final String COURSE_ID_REQUIRED = "courseId가 누락되었습니다";
+    public static final String POSITIVE_NUMBER_REQUIRED = "body의 특정 필드가 양수여야 합니다";
 }

--- a/src/main/java/com/econo_4factorial/newproject/course/controller/BookmarkController.java
+++ b/src/main/java/com/econo_4factorial/newproject/course/controller/BookmarkController.java
@@ -4,8 +4,10 @@ import com.econo_4factorial.newproject.common.annotation.UserId;
 import com.econo_4factorial.newproject.common.util.api.ApiResponse;
 import com.econo_4factorial.newproject.common.util.api.ApiResult;
 import com.econo_4factorial.newproject.course.dto.CourseWithBookmarkDTO;
+import com.econo_4factorial.newproject.course.dto.req.AddBookmarkReq;
 import com.econo_4factorial.newproject.course.dto.res.GetBookmarkListRes;
 import com.econo_4factorial.newproject.course.service.BookmarkService;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -18,12 +20,12 @@ import java.util.List;
 public class BookmarkController {
     private final BookmarkService bookmarkService;
 
-    @PostMapping("/{courseId}")
+    @PostMapping
     public ApiResult<ApiResult.SuccessBody<Void>> addBookmark (
             @UserId Long userId,
-            @PathVariable(name="courseId") Long courseId
+            @RequestBody @Valid AddBookmarkReq addBookmarkReq
     ) {
-        bookmarkService.addBookmark(userId, courseId);
+        bookmarkService.addBookmark(userId, addBookmarkReq.courseId());
         return ApiResponse.success(HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/econo_4factorial/newproject/course/dto/req/AddBookmarkReq.java
+++ b/src/main/java/com/econo_4factorial/newproject/course/dto/req/AddBookmarkReq.java
@@ -1,0 +1,12 @@
+package com.econo_4factorial.newproject.course.dto.req;
+
+import com.econo_4factorial.newproject.common.exception.ValidationMessage;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record AddBookmarkReq(
+        @NotNull(message = ValidationMessage.COURSE_ID_REQUIRED)
+        @Positive(message = ValidationMessage.POSITIVE_NUMBER_REQUIRED)
+        Long courseId
+) {
+}

--- a/src/main/java/com/econo_4factorial/newproject/course/service/CourseService.java
+++ b/src/main/java/com/econo_4factorial/newproject/course/service/CourseService.java
@@ -26,6 +26,7 @@ public class CourseService {
     public List<CourseWithBookmarkDTO> getAllCoursesWithBookmark(Long userId, Long mountainId, String sortBy) {
         CourseSearchCondition courseSearchCondition = CourseSearchCondition.of(mountainId, sortBy);
         return courseRepository.findAllByMountainIdWithBookmark(courseSearchCondition, mountainId, userId);
+    }
 
     @Transactional(readOnly = true)
     public CourseDetailDTO getCourseDetailsByCourseId(Long courseId) {


### PR DESCRIPTION
## #️⃣연관된 이슈

#79 

## 📝작업 내용

- 북마크 등록 시 courseId를 요청 body를 통해서 받도록 리팩토링
- `feat-#30 PR`을 병합하면서 빠뜨린 `중괄호 {` 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 북마크 추가 시 요청 본문에서 courseId를 받도록 변경되었습니다.
  * courseId 필드에 대해 필수 및 양수 여부를 검증하는 기능이 추가되었습니다.

* **버그 수정**
  * 일부 서비스 메서드의 문법 오류가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->