### PR TITLE
refactor: 프론트의 로그인 성공 시 Redirect 주소를 .env 파일을 통해 관리하도록 수정

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Auth", description = "인증 API")
 public class OAuthController {
     private final OAuthService oAuthService;
+    private final RedirectUriBuilder redirectUriBuilder;
 
     @GetMapping("/kakao/login")
     @Operation(summary = "카카오 로그인 URI 요청", description = "프론트에서 카카오 로그인 페이지로 리다이렉트하기 위한 URI를 반환합니다.")
@@ -37,7 +38,7 @@ public class OAuthController {
             @Parameter(description = "카카오 인가 코드", example = "abc123", required = true)
             @RequestParam("code") String kakaoAuthorizationCode) {
         AuthToken authToken = oAuthService.loginWithKaKao(kakaoAuthorizationCode);
-        HttpHeaders headers = HttpHeadersGenerator.setLocation(RedirectUriBuilder.buildLoginSuccessUri(authToken));
+        HttpHeaders headers = HttpHeadersGenerator.setLocation(redirectUriBuilder.buildLoginSuccessUri(authToken));
         return ApiResponse.success(headers, HttpStatus.FOUND);
     }
 
@@ -45,7 +46,7 @@ public class OAuthController {
     @Operation(summary = "애플 로그인", description = "애플 ID 토큰을 기반으로 로그인 처리합니다.")
     public ApiResult<ApiResult.SuccessBody<Void>> loginWithApple (@RequestBody @Valid AppleLoginReq appleLoginReq) {
         AuthToken authToken = oAuthService.loginWithApple(appleLoginReq);
-        HttpHeaders headers = HttpHeadersGenerator.setLocation(RedirectUriBuilder.buildLoginSuccessUri(authToken));
+        HttpHeaders headers = HttpHeadersGenerator.setLocation(redirectUriBuilder.buildLoginSuccessUri(authToken));
         return ApiResponse.success(headers, HttpStatus.FOUND);
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/exception/GlobalExceptionHandler.java
@@ -26,6 +26,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @RequiredArgsConstructor
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     private static final String ERROR = "error";
+    private final RedirectUriBuilder redirectUriBuilder;
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(
@@ -86,7 +87,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         ErrorType errorType = ex.getErrorType();
         log.error("[예외 발생] {}, {}", errorType.getErrorCode(), errorType.getMessage(), ex);
 
-        HttpHeaders headers = HttpHeadersGenerator.setLocation(RedirectUriBuilder.buildLoginFailUri());
+        HttpHeaders headers = HttpHeadersGenerator.setLocation(redirectUriBuilder.buildLoginFailUri());
         return ApiResponse.fail(
                 errorType.getErrorCode(),
                 errorType.getMessage(),

--- a/src/main/java/com/econo_4factorial/newproject/common/util/RedirectUriBuilder.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/util/RedirectUriBuilder.java
@@ -2,12 +2,16 @@ package com.econo_4factorial.newproject.common.util;
 
 
 import com.econo_4factorial.newproject.auth.jwt.AuthToken;
-import lombok.experimental.UtilityClass;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
-@UtilityClass
+@Component
+@RequiredArgsConstructor
 public class RedirectUriBuilder {
-    private final String baseUri = "http://soop.euichan.com/social-login-loading";
+    @Value("${auth.login_success.base_uri}")
+    private String baseUri;
 
     public String buildLoginSuccessUri (AuthToken authToken) {
         return UriComponentsBuilder.fromUriString(baseUri)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,7 @@ spring:
         - kakao
         - apple
         - metrics
+
+auth:
+  login_success:
+    base_uri: ${LOGIN_SUCCESS_BASE_URI}


### PR DESCRIPTION
## #️⃣연관된 이슈

#92 

## 📝작업 내용

로그인 성공 시 프론트로 Redirect 되는 주소를 .env 파일을 통해 관리하도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

프론트 테스트를 위해서 긴급히 필요한 수정사항이라 일단 머지시키겠습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 로그인 성공 및 실패 리다이렉트 URI가 외부 설정값을 사용하도록 개선되었습니다.
  * 내부적으로 URI 생성 방식이 인스턴스 기반으로 변경되어, 환경 설정을 통한 유연한 관리가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->