### PR TITLE
[BE-35]refactor: 애플 로그인 API response 방식 변경

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
@@ -1,5 +1,6 @@
 package com.econo_4factorial.newproject.auth.controller;
 
+import com.econo_4factorial.newproject.auth.dto.Res.AppleLoginRes;
 import com.econo_4factorial.newproject.auth.dto.Res.KakaoUriRes;
 import com.econo_4factorial.newproject.auth.dto.Req.AppleLoginReq;
 import com.econo_4factorial.newproject.auth.jwt.AuthToken;
@@ -44,9 +45,8 @@ public class OAuthController {
 
     @PostMapping("/apple/login")
     @Operation(summary = "애플 로그인", description = "애플 ID 토큰을 기반으로 로그인 처리합니다.")
-    public ApiResult<ApiResult.SuccessBody<Void>> loginWithApple (@RequestBody @Valid AppleLoginReq appleLoginReq) {
+    public ApiResult<ApiResult.SuccessBody<AppleLoginRes>> loginWithApple (@RequestBody @Valid AppleLoginReq appleLoginReq) {
         AuthToken authToken = oAuthService.loginWithApple(appleLoginReq);
-        HttpHeaders headers = HttpHeadersGenerator.setLocation(redirectUriBuilder.buildLoginSuccessUri(authToken));
-        return ApiResponse.success(headers, HttpStatus.FOUND);
+        return ApiResponse.success(AppleLoginRes.from(authToken), HttpStatus.FOUND);
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/auth/dto/Res/AppleLoginRes.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/dto/Res/AppleLoginRes.java
@@ -1,0 +1,13 @@
+package com.econo_4factorial.newproject.auth.dto.Res;
+
+import com.econo_4factorial.newproject.auth.jwt.AuthToken;
+
+public record AppleLoginRes (
+        String accessToken,
+        String refreshToken,
+        Long expirationTime
+){
+    public static AppleLoginRes from (AuthToken authToken) {
+        return new AppleLoginRes(authToken.accessToken(), authToken.refreshToken(), authToken.expirationTime());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈번호

#94 

## 📝작업 내용

- 애플 로그인 API 응답 방식을 201 상태코드 + body에 토큰 정보를 담도록 리팩토링

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

프론트의 요청으로 긴급히 머지시키겠습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * Apple 로그인을 완료하면 액세스 토큰, 리프레시 토큰, 만료 시간이 포함된 정보를 응답에서 직접 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->