### PR TITLE
[INFRA-9] chore: taskdefinition에 새로운 env LOGIN_SUCCESS_BASE_URI 추가

### DIFF
--- a/.github/ecs/task-definition.json
+++ b/.github/ecs/task-definition.json
@@ -104,6 +104,10 @@
                 {
                     "name": "REDIS_PORT",
                     "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:650553045794:secret:java-b6ARto:REDIS_PORT::"
+                },
+                {
+                    "name": "LOGIN_SUCCESS_BASE_URI",
+                    "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:650553045794:secret:java-b6ARto:LOGIN_SUCCESS_BASE_URI::"
                 }
             ],
             "ulimits": [],


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #96 

## 📝작업 내용

> taskdefinition에 새로운 env LOGIN_SUCCESS_BASE_URI을 secrets manager에서 참조하도록 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ECS 작업 정의에 새로운 비밀 환경 변수 `LOGIN_SUCCESS_BASE_URI`가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->