### PR TITLE
[BE-36]feat: Course 도메인에 이미지 url 추가

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/course/domain/Course.java
+++ b/src/main/java/com/econo_4factorial/newproject/course/domain/Course.java
@@ -30,4 +30,7 @@ public class Course {
 
     @Enumerated(EnumType.STRING)
     private Difficulty difficulty;
+
+    @Column(nullable = false)
+    private String imageUrl;
 }

--- a/src/main/java/com/econo_4factorial/newproject/course/dto/CourseWithBookmarkDTO.java
+++ b/src/main/java/com/econo_4factorial/newproject/course/dto/CourseWithBookmarkDTO.java
@@ -9,7 +9,8 @@ public record CourseWithBookmarkDTO(
         Double length,
         Long duration,
         Difficulty difficulty,
-        Boolean bookmark
+        Boolean bookmark,
+        String image
 ) {
     public static CourseWithBookmarkDTO from(Course course, Boolean isBookmark){
         return new CourseWithBookmarkDTO(
@@ -18,7 +19,8 @@ public record CourseWithBookmarkDTO(
                 course.getLength(),
                 course.getDuration(),
                 course.getDifficulty(),
-                isBookmark
+                isBookmark,
+                course.getImageUrl()
         );
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/course/repository/CourseCustomRepositoryImpl.java
+++ b/src/main/java/com/econo_4factorial/newproject/course/repository/CourseCustomRepositoryImpl.java
@@ -38,7 +38,8 @@ public class CourseCustomRepositoryImpl implements CourseCustomRepository {
                         course.difficulty,
                         new CaseBuilder()
                                 .when(bookmark.id.isNotNull()).then(true)
-                                .otherwise(false)
+                                .otherwise(false),
+                        course.imageUrl
                 ))
                 .from(course)
                 .leftJoin(bookmark).on(

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -143,13 +143,9 @@ VALUES(1,  'https://oasis-joa.s3.ap-northeast-2.amazonaws.com/soop/mock1.png'),
       (28, 'https://oasis-joa.s3.ap-northeast-2.amazonaws.com/soop/mock2.png')
 ON DUPLICATE KEY UPDATE image_url = VALUES(image_url);
 
-INSERT INTO course(mountain_id, name, length, duration, difficulty)
-VALUES (1, '세인봉-입석대 코스', 6.8, 210, 'NORMAL'),
-       (1, '늦재-옛길 코스', 10.4, 350, 'NORMAL'),
-       (1, '당산나무 코스', 4, 95, 'NORMAL'),
-       (1, '시무지기폭포 코스', 12, 355, 'NORMAL'),
-       (1, '너릿재-옛길코스', 14.5, 440, 'NORMAL'),
-       (1, '안양산-북산 코스', 14.6, 420, 'NORMAL'),
-       (1, '도원마을-규봉 코스', 7.5, 270, 'NORMAL'),
-       (1, '교리-만연산 코스', 7.5, 240, 'NORMAL')
+INSERT INTO course(mountain_id, name, length, duration, difficulty, image_url)
+VALUES (1, '늦재-옛길 코스', 10.4, 350, 'NORMAL','https://oasis-joa.s3.ap-northeast-2.amazonaws.com/soop/늦재-옛길.png'),
+       (1, '당산나무 코스', 4, 95, 'NORMAL','https://oasis-joa.s3.ap-northeast-2.amazonaws.com/soop/당산나무+코스.png'),
+       (1, '시무지기폭포 코스', 12, 355, 'NORMAL','https://oasis-joa.s3.ap-northeast-2.amazonaws.com/soop/시무지기폭포+코스.png'),
+       (1, '너릿재-옛길코스', 14.5, 440, 'NORMAL', 'https://oasis-joa.s3.ap-northeast-2.amazonaws.com/soop/너릿재-옛길+코스.png')
 ON DUPLICATE KEY update name = VALUES(name);


### PR DESCRIPTION
## #️⃣연관된 이슈

#98 

## 📝작업 내용

- Course 도메인에 imageUrl 추가
- Course 정보 조회 시, imageUrl도 포함되게끔 리팩터링
- data.sql의 course 데이터에 image_url 값 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
급히 먼저 선반영 하겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 코스 정보에 이미지 URL이 추가되어, 코스별 이미지를 확인할 수 있습니다.

* **데이터 변경**
  * 기본 제공 코스 데이터에 이미지 URL 컬럼이 추가되었으며, 예시 데이터가 일부 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->