### PR TITLE
[BE-41] feat: 소켓 통신 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    //Socket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
@@ -48,10 +48,7 @@ public class OAuthController {
     @PostMapping("/apple/login")
     @Operation(summary = "애플 로그인", description = "애플 ID 토큰을 기반으로 로그인 처리합니다.")
     public ApiResult<ApiResult.SuccessBody<AppleLoginRes>> loginWithApple (@RequestBody @Valid AppleLoginReq appleLoginReq) {
-        log.info("애플 로그인 요청: {}", appleLoginReq);
-
         AuthToken authToken = oAuthService.loginWithApple(appleLoginReq);
-        log.info("생성된 토큰 : {}", authToken);
         return ApiResponse.success(AppleLoginRes.from(authToken), HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/common/config/WebSocketConfig.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/config/WebSocketConfig.java
@@ -1,0 +1,21 @@
+package com.econo_4factorial.newproject.common.config;
+
+import com.econo_4factorial.newproject.travel.handler.WebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+    private final WebSocketHandler webSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(webSocketHandler, "/travel")
+                .setAllowedOrigins("*");
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/travel/handler/WebSocketHandler.java
+++ b/src/main/java/com/econo_4factorial/newproject/travel/handler/WebSocketHandler.java
@@ -1,0 +1,41 @@
+package com.econo_4factorial.newproject.travel.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@Slf4j
+public class WebSocketHandler extends TextWebSocketHandler {
+    private static final ConcurrentHashMap<String, WebSocketSession> clients = new ConcurrentHashMap<>();
+
+    @Override //추후 구현예정
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+
+    }
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        addSession(session);
+        log.info("Websocket 연결 성공. sessionId={}", session.getId());
+    }
+
+    private void addSession(WebSocketSession session) {
+        clients.put(session.getId(), session);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        deleteSession(session);
+        log.info("Websocket 연결 종료. sessionId={}", session.getId());
+    }
+
+    private void deleteSession(WebSocketSession session) {
+        clients.remove(session.getId());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#108 

## 📝작업 내용

- 웹소켓 통신 환경 설정
- 웹소켓 Handler 구현

### 스크린샷 (선택)
### 유저1 
<img width="601" height="351" alt="image" src="https://github.com/user-attachments/assets/ad1b0984-6338-4e01-ac1a-6a016bf728f0" />

### 유저2 
<img width="608" height="327" alt="image" src="https://github.com/user-attachments/assets/5c3b565c-b983-4d84-adba-e0c362b54bbd" />


## 💬리뷰 요구사항(선택)
간단하게 소켓 통신을 구현하였습니다. 올라간 코드에서는 사용자끼리 메시지를 주고받는 코드는 없애고 올렸습니다. 따라서 소켓 통신을 해보고 싶다면 아래 코드를 `webSocketHanlder` 에 추가하시면 됩니다

```java 
    @Override
    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
        clients.forEach((id, socketSession) -> {
            try {
                if(isNotSenderId(session.getId(), id))
                    socketSession.sendMessage(message);
            } catch (IOException e) {
                log.error("에러 발생 ", e);
            }
        });
    }

    private boolean isNotSenderId(String senderId, String id) {
        return !senderId.equals(id);
    }
```    

웹 소켓의 동작에 대해서 간단히 말씀드리면, 

1. 먼저 저희가 정한 웹소켓 엔드포인트인 `travel` 로 요청이 옵니다. 즉 `ws://localhost:8080/travel` 로 요청이 오게 됩니다

2. 요청이 오면,  소켓을 연결시키게 됩니다 (여기까지는 `webSocketConfig` 를 통해서 알아서 백그라운드에서 이루어집니다)

3. 소켓 연결 직후
`afterConnectionEstablished` 메소드가 동작합니다
- 해당 메소드에서는 유저들의 세션(연결)들을 한 곳에서 관리하기 위해 `clients` 라는 `HashMap` 에 담습니다 =>

4. 클라이언트에게 메시지가 오는 경우
`handleTextMessage()` 메소드가 동작합니다.

5. 클라이언트와의 연결이 끊긴 경우
`afterConnectionClosed()` 메소드가 동작합니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket 지원이 추가되어 실시간 통신 기능이 활성화되었습니다.
  * 새로운 WebSocket 엔드포인트(`/travel`)가 도입되었습니다.

* **Refactor**
  * Apple 로그인 관련 불필요한 로그 출력이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->