### PR TITLE
feat: 온프레미스 CICD 초기 파이프라인 추가

### DIFF
--- a/.github/workflows/onprem-dev.yml
+++ b/.github/workflows/onprem-dev.yml
@@ -1,0 +1,54 @@
+name: Raspberry Pi Spring Boot CICD
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      #- name: Cache Gradle #캐시는 잠시 보류
+        #uses: actions/cache@v4
+        #with:
+          #path: |
+            #~/.gradle/caches
+            #~/.gradle/wrapper
+          #key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          #restore-keys: |
+            #${{ runner.os }}-gradle-
+
+      - name: Build Spring Boot app
+        run: ./gradlew clean build -x test
+
+      - name: Deploy JAR to Raspberry Pi
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ONPREM_HOST }}
+          username: ${{ secrets.ONPREM_USER }}
+          password: ${{ secrets.ONPREM_SSH_PASSWORD }}
+          port: ${{ secrets.ONPREM_SSH_PORT }}
+          source: build/libs/*.jar
+          target: /home/${{ secrets.ONPREM_USER }}/soop/infra/backend/New-Project-BE/
+
+      - name: Restart Spring Boot on Raspberry Pi
+        uses: appleboy/ssh-action@v1.1.0
+        with:
+          host: ${{ secrets.ONPREM_HOST }}
+          username: ${{ secrets.ONPREM_USER }}
+          password: ${{ secrets.ONPREM_SSH_PASSWORD }}
+          port: ${{ secrets.ONPREM_SSH_PORT }}
+          script: |
+            pkill -f 'java -jar' || true #우아하게 종료할 수 있도록 gracefull shutdown 추가
+            nohup java -jar /home/${{ secrets.ONPREM_USER }}/soop/infra/backend/New-Project-BE/build/libs/NewProject-0.0.1-SNAPSHOT.jar --server.port=8080 > app.log 2>&1 & #애플리케이션에서 로거가 추가 되면 삭제


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #111 

## 📝작업 내용

> 동방 라즈베리파이 서버에 CICD를 적용하였습니다. 작동 테스트를 위한 최소 기능만 탑재했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * "dev" 브랜치에 푸시 시 Raspberry Pi에 Spring Boot 애플리케이션을 자동으로 빌드, 배포, 재시작하는 GitHub Actions 워크플로우가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->