### PR TITLE
[BE-43]bug: UserIdResolver에서 Bearer 접두어 제거

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/jwt/service/JwtTokenProvider.java
@@ -2,7 +2,6 @@ package com.econo_4factorial.newproject.auth.jwt.service;
 
 import com.econo_4factorial.newproject.auth.exception.BadRequestException.ExpiredTokenException;
 import com.econo_4factorial.newproject.auth.exception.BadRequestException.InvalidTokenHeaderException;
-import com.econo_4factorial.newproject.auth.exception.BadRequestException.LoggedOutTokenException;
 import com.econo_4factorial.newproject.auth.exception.BadRequestException.SignatureException;
 import com.econo_4factorial.newproject.auth.jwt.TokenType;
 import com.econo_4factorial.newproject.auth.jwt.repository.RefreshTokenRepository;

--- a/src/main/java/com/econo_4factorial/newproject/common/annotation/resolver/UserIdResolver.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/annotation/resolver/UserIdResolver.java
@@ -29,8 +29,10 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
-        return Optional.ofNullable(webRequest.getHeader(HttpHeaders.AUTHORIZATION))
-                .map(jwtTokenProvider::getUserIdFromAccessToken)
-                .orElseThrow(NotExistTokenException::new);
+        String header = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header == null) throw new NotExistTokenException();
+
+        String token = jwtTokenProvider.extractToken(header);
+        return jwtTokenProvider.getUserIdFromAccessToken(token);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #115 

## 📝작업 내용

UserIdResolver가 Bearer 접두어를 제거하지 않아 발생한 JWT 파싱 오류 수정

> S2-03 엔드포인트 호출 시 `io.jsonwebtoken.MalformedJwtException: Compact JWT strings may not contain whitespace.` 예외가 발생했습니다. 해당 요청에서 `getUserIdFromAccessToken()`이 2회 호출되는 로그가 확인되었습니다.
JwtInterceptor에서 인가 확인 과정 중 1회, UserIdResolver에서 컨트롤러 인자 주입 시 1회.
2번째 호출에서 오류가 발생했습니다. `UserIdResolver`가 Authorization 헤더 값을 그대로 `JwtTokenProvider.getUserIdFromAccessToken()`에 전달했습니다. 이때 헤더에는 "Bearer <token>" 형식의 접두어와 공백이 포함되어 있어 JWT가 “whitespace 포함 불가”로 판단, 파싱에 실패했습니다.
`UserIdResolver`에 `extractToken` 호출을 추가하여 Authorization 헤더에서 Bearer 접두어를 제거한 뒤 `getUserIdFromAccessToken()`에 전달하도록 수정했습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능

- 버그 수정
  - 요청 헤더에 토큰이 없거나 형식이 잘못된 경우를 명확히 감지해 일관된 인증 오류를 반환합니다. 토큰 추출 과정을 분리해 가장자리 사례 처리 신뢰성을 높였습니다.

- 리팩터링
  - 토큰 추출과 사용자 ID 해석 단계를 분리하여 가독성과 유지보수성을 개선했습니다. 외부 동작 변화는 없습니다.

- Chores
  - 사용되지 않는 import를 제거해 빌드 경고를 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->