### PR TITLE
[BE-48] feat: 프로필 설정 여부 확인 API

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/user/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/UserController.java
@@ -1,0 +1,28 @@
+package com.econo_4factorial.newproject.user;
+
+import com.econo_4factorial.newproject.common.annotation.UserId;
+import com.econo_4factorial.newproject.common.util.api.ApiResponse;
+import com.econo_4factorial.newproject.common.util.api.ApiResult;
+import com.econo_4factorial.newproject.user.dto.res.GetProfileStatusRes;
+import com.econo_4factorial.newproject.user.service.UserService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@AllArgsConstructor
+@RestController
+@RequestMapping("api/v1/users")
+@Tag(name = "User", description = "유저 관련 API")
+public class UserController {
+    private final UserService userService;
+
+    @GetMapping("/profile/status")
+    public ApiResult<ApiResult.SuccessBody<GetProfileStatusRes>> getProfileStatus (@UserId Long userId) {
+        Boolean result = userService.isProfileComplete(userId);
+        return ApiResponse.success(GetProfileStatusRes.from(result), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/UserController.java
@@ -21,7 +21,7 @@ public class UserController {
 
     @GetMapping("/profile/status")
     public ApiResult<ApiResult.SuccessBody<GetProfileStatusRes>> getProfileStatus (@UserId Long userId) {
-        Boolean result = userService.isProfileComplete(userId);
+        Boolean result = userService.isProfileFilled(userId);
         return ApiResponse.success(GetProfileStatusRes.from(result), HttpStatus.OK);
     }
 

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -30,6 +30,8 @@ public class User extends BaseEntity {
     @Column(unique = true)
     private String appleSub;
 
+    private String nickname;
+
     @Builder(builderMethodName = "kakaoUserBuilder", builderClassName = "kakaoUserBuilder")
     public User(String email, String name, Long kakaoId) {
         this.userInfo = new UserInfo(email, name);
@@ -41,4 +43,23 @@ public class User extends BaseEntity {
         this.userInfo = new UserInfo(email, name);
         this.appleSub = appleSub;
     }
+
+    public Boolean isProfileComplete() {
+        return isNicknameNotNull()
+        && isEmailNotNull()
+        && isPhoneNumberNotNull();
+    }
+
+    private Boolean isNicknameNotNull() {
+        return this.nickname != null;
+    }
+
+    private boolean isEmailNotNull() {
+        return this.userInfo.getEmail() != null;
+    }
+
+    private boolean isPhoneNumberNotNull() {
+        return this.userInfo.getPhoneNumber() != null;
+    }
+
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -44,21 +44,21 @@ public class User extends BaseEntity {
         this.appleSub = appleSub;
     }
 
-    public Boolean isProfileComplete() {
-        return isNicknameNotNull()
-        && isEmailNotNull()
-        && isPhoneNumberNotNull();
+    public Boolean isProfileFilled() {
+        return hasNickname()
+                && hasEmail()
+                && hasPhoneNumber();
     }
 
-    private Boolean isNicknameNotNull() {
+    private Boolean hasNickname() {
         return this.nickname != null;
     }
 
-    private boolean isEmailNotNull() {
+    private boolean hasEmail() {
         return this.userInfo.getEmail() != null;
     }
 
-    private boolean isPhoneNumberNotNull() {
+    private boolean hasPhoneNumber() {
         return this.userInfo.getPhoneNumber() != null;
     }
 

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/res/GetProfileStatusRes.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/res/GetProfileStatusRes.java
@@ -1,0 +1,9 @@
+package com.econo_4factorial.newproject.user.dto.res;
+
+public record GetProfileStatusRes(
+        Boolean isComplete
+) {
+    public static GetProfileStatusRes from (Boolean bool) {
+        return new GetProfileStatusRes(bool);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -40,4 +40,10 @@ public class UserService {
     private User addAppleUser(AppleUserInfoDTO userInfo) {
         return userRepository.save(toEntity(userInfo));
     }
+
+    @Transactional(readOnly = true)
+    public Boolean isProfileComplete(Long userId) {
+        User user = findUserByIdOrThrow(userId);
+        return user.isProfileComplete();
+    }
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -42,8 +42,8 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public Boolean isProfileComplete(Long userId) {
+    public Boolean isProfileFilled(Long userId) {
         User user = findUserByIdOrThrow(userId);
-        return user.isProfileComplete();
+        return user.isProfileFilled();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#125 

## 📝작업 내용

- `User` 도메인 모델에 nickname 필드 추가
- `User` 도메인 모델에 프로필 정보 설정이 모두 되어있는지 체크하는 도메인 로직 구현
- 유저의 프로필 설정 여부 확인 API  구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
제가 고민했던 부분은 
> 프로필 정보 확인은 구체적으로 어떤 행동을 해야할까?

였습니다. 제가 로직을 고민했을 때 들었던 `프로필 정보 확인 로직`은 아래 두 가지 선택지 중 하나로 결론지었습니다
- 단순히 `닉네임, 휴대폰번호, 이메일` 값에 대해서 `null값 체크`만 진행한다
- `닉네임, 휴대폰번호, 이메일` 에 `null값 체크` + `올바른 값이 들어가있는지 유효성검사도 거친다`

저는 첫 번째 방식인 `null값 체크` 방식을 택하였습니다.  그 이유로는
1. 구현하려는 기능은 프로필 설정 `여부` 확인 기능입니다. 따라서 유효성 검사를 여기서 진행하는 것은 불필요한 로직이 추가되는 것이라고 판단하였습니다
2. `닉네임, 휴대폰번호, 이메일` 값들에 대한 유효성 검사는 해당 필드들이 새로운 값으로 업데이트 될 때 진행하면 된다. 그러면 조회 시에는 안전한 값들이 들어있을 수 밖에 없다. 물론 프로필 정보가 완전하지 않은 상태로 프로필 정보를 조회한다면 `null값`들이 들어있을 수는 있다. 하지만 이는 프론트 쪽에서 프로필 정보 확인 API를 홈화면에서 지속적으로 호출한다고 하였으니, `null값`이 들어있는 프로필 정보를 조회할 기능은 없어보인다 라고 판단했습니다

사실 지금 이 PR을 작성하는 과정에서 `유효성 검사는 언제해야될까?` 라는 질의가 떠올랐습니다. 단순하게 제 생각으로는 `새로운 데이터가 생성될 때, 또는 새로운 데이터로 업데이트가 될 때`만 유효성 검사를 하면 된다고 생각이 듭니다. 왜냐하면 유효성 검사라는 건 결국 데이터가 우리의 비즈니스 규칙에 맞는 값을 가지도록 하는 안전장치이기에, 새로운 데이터가 생성되거나 업데이트 될 때만 유효성 검사를 진행하면 된다고 생각이 듭니다. 지금 생각해보면 고민할 필요가 없는 고민이였지만, 이 또한 나중에 밑거름이 될 것 같네요 😄 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 로그인된 사용자의 프로필 완성 여부를 확인하는 새 엔드포인트가 추가되었습니다 (/api/v1/users/profile/status). 필수 정보가 채워졌는지 여부를 Boolean 형태로 반환합니다.
  - 프로필 완전성 판정에 닉네임이 포함되어 검사 범위가 확장되었습니다.
- 문서
  - 새 엔드포인트가 API 문서에 반영되어 탐색 및 테스트가 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->