### PR TITLE
[BE-51] feat : 닉네임 중복 체크 API

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/common/annotation/ValidEmailPattern.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/annotation/ValidEmailPattern.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = ValidEmailPatternValidator.class)
 public @interface ValidEmailPattern {
-    String message() default ValidationMessage.EMAIL_INVALID_PATTERN;
+    String message() default ValidationMessage.EMAIL_PATTERN_INVALID;
     Class[] groups() default {};
     Class[] payload() default {};
 }

--- a/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
@@ -10,7 +10,7 @@ public class ValidationMessage {
     public static final String POSITIVE_NUMBER_REQUIRED = "body의 특정 필드가 양수여야 합니다";
     public static final String NICKNAME_IS_REQUIRED = "nickname이 누락되었습니다.";
     public static final String NICKNAME_LENGTH_INVALID = "닉네임은 2자 이상 12자 이하로 입력해야 합니다.";
-    public static final String NICKNAME_PATTERN_INVALID = "닉네임은 한글, 영문, 숫자만 입력할 수 있습니다.";;
+    public static final String NICKNAME_PATTERN_INVALID = "닉네임은 한글, 영문, 숫자만 입력할 수 있습니다.";
     public static final String PHONE_NUMBER_IS_REQUIRED = "전화번호는 필수입니다.";
     public static final String PHONE_NUMBER_INVALID = "전화번호 형식이 올바르지 않습니다.";
     public static final String VERIFICATION_CODE_IS_REQUIRED = "인증번호는 필수입니다.";

--- a/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
@@ -4,10 +4,13 @@ public class ValidationMessage {
     public static final String IDENTITY_TOKEN_REQUIRED = "identityToken이 누락되었습니다";
     public static final String FAMILY_NAME_REQUIRED = "familyName이 누락되었습니다";
     public static final String GIVEN_NAME_REQUIRED = "givenName이 누락되었습니다";
-    public static final String EMAIL_INVALID_PATTERN = "email이 올바르지 않은 패턴입니다";
+    public static final String EMAIL_PATTERN_INVALID = "email이 올바르지 않은 패턴입니다";
     public static final String REFRESH_TOKEN_REQUIRED = "refreshToken이 누락되었습니다";
     public static final String COURSE_ID_REQUIRED = "courseId가 누락되었습니다";
     public static final String POSITIVE_NUMBER_REQUIRED = "body의 특정 필드가 양수여야 합니다";
+    public static final String NICKNAME_IS_REQUIRED = "nickname이 누락되었습니다.";
+    public static final String NICKNAME_LENGTH_INVALID = "닉네임은 2자 이상 12자 이하로 입력해야 합니다.";
+    public static final String NICKNAME_PATTERN_INVALID = "닉네임은 한글, 영문, 숫자만 입력할 수 있습니다.";;
     public static final String PHONE_NUMBER_IS_REQUIRED = "전화번호는 필수입니다.";
     public static final String PHONE_NUMBER_INVALID = "전화번호 형식이 올바르지 않습니다.";
     public static final String VERIFICATION_CODE_IS_REQUIRED = "인증번호는 필수입니다.";

--- a/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
@@ -3,13 +3,17 @@ package com.econo_4factorial.newproject.user.controller;
 import com.econo_4factorial.newproject.common.annotation.UserId;
 import com.econo_4factorial.newproject.common.util.api.ApiResponse;
 import com.econo_4factorial.newproject.common.util.api.ApiResult;
+import com.econo_4factorial.newproject.user.dto.res.GetNicknameAvailabilityRes;
 import com.econo_4factorial.newproject.user.dto.res.GetProfileStatusRes;
 import com.econo_4factorial.newproject.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @AllArgsConstructor
@@ -20,9 +24,20 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/profile/status")
+    @Operation(summary = "프로필 설정 여부 확인", description = "프로필 설정(기본정보/개인정보) 여부 값을 반환합니다.")
     public ApiResult<ApiResult.SuccessBody<GetProfileStatusRes>> getProfileStatus (@UserId Long userId) {
         Boolean result = userService.isProfileFilled(userId);
         return ApiResponse.success(GetProfileStatusRes.from(result), HttpStatus.OK);
+    }
+
+    @GetMapping("/nickname/check")
+    @Operation(summary = "닉네임 중복 확인", description = "닉네임 중복을 체크합니다.")
+    public ApiResult<ApiResult.SuccessBody<GetNicknameAvailabilityRes>> checkNicknameUnique (
+            @Parameter(name = "nickname", description = "닉네임", required = true)
+            @RequestParam String nickname
+    ) {
+        Boolean result = userService.isNicknameUnique(nickname);
+        return ApiResponse.success(GetNicknameAvailabilityRes.from(result), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
@@ -36,7 +36,7 @@ public class UserController {
             @Parameter(name = "nickname", description = "닉네임", required = true)
             @RequestParam String nickname
     ) {
-        Boolean result = userService.isNicknameUnique(nickname);
+        boolean result = userService.isNicknameUnique(nickname);
         return ApiResponse.success(GetNicknameAvailabilityRes.from(result), HttpStatus.OK);
     }
 

--- a/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
@@ -3,12 +3,14 @@ package com.econo_4factorial.newproject.user.controller;
 import com.econo_4factorial.newproject.common.annotation.UserId;
 import com.econo_4factorial.newproject.common.util.api.ApiResponse;
 import com.econo_4factorial.newproject.common.util.api.ApiResult;
+import com.econo_4factorial.newproject.user.dto.req.CheckNicknameReq;
 import com.econo_4factorial.newproject.user.dto.res.GetNicknameAvailabilityRes;
 import com.econo_4factorial.newproject.user.dto.res.GetProfileStatusRes;
 import com.econo_4factorial.newproject.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,9 +36,9 @@ public class UserController {
     @Operation(summary = "닉네임 중복 확인", description = "닉네임 중복을 체크합니다.")
     public ApiResult<ApiResult.SuccessBody<GetNicknameAvailabilityRes>> checkNicknameUnique (
             @Parameter(name = "nickname", description = "닉네임", required = true)
-            @RequestParam String nickname
-    ) {
-        boolean result = userService.isNicknameUnique(nickname);
+            @Valid CheckNicknameReq checkNicknameReq
+            ) {
+        boolean result = userService.isNicknameUnique(checkNicknameReq.nickname());
         return ApiResponse.success(GetNicknameAvailabilityRes.from(result), HttpStatus.OK);
     }
 

--- a/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
@@ -1,4 +1,4 @@
-package com.econo_4factorial.newproject.user;
+package com.econo_4factorial.newproject.user.controller;
 
 import com.econo_4factorial.newproject.common.annotation.UserId;
 import com.econo_4factorial.newproject.common.util.api.ApiResponse;

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -30,6 +30,7 @@ public class User extends BaseEntity {
     @Column(unique = true)
     private String appleSub;
 
+    @Column(unique = true)
     private String nickname;
 
     @Builder(builderMethodName = "kakaoUserBuilder", builderClassName = "kakaoUserBuilder")

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/req/CheckNicknameReq.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/req/CheckNicknameReq.java
@@ -1,0 +1,17 @@
+package com.econo_4factorial.newproject.user.dto.req;
+
+import com.econo_4factorial.newproject.common.exception.ValidationMessage;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CheckNicknameReq(
+        @NotNull(message = ValidationMessage.NICKNAME_IS_REQUIRED)
+        @Size(min = 2, max = 12, message = ValidationMessage.NICKNAME_LENGTH_INVALID)
+        @Pattern(
+                regexp = "^[가-힣a-zA-Z0-9]+$",
+                message = ValidationMessage.NICKNAME_PATTERN_INVALID
+        )
+        String nickname
+) {
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/res/GetNicknameAvailabilityRes.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/res/GetNicknameAvailabilityRes.java
@@ -1,0 +1,9 @@
+package com.econo_4factorial.newproject.user.dto.res;
+
+public record GetNicknameAvailabilityRes(
+        Boolean isAvailable
+) {
+    public static GetNicknameAvailabilityRes from(Boolean isAvailable) {
+        return new GetNicknameAvailabilityRes(isAvailable);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/res/GetNicknameAvailabilityRes.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/res/GetNicknameAvailabilityRes.java
@@ -1,9 +1,9 @@
 package com.econo_4factorial.newproject.user.dto.res;
 
 public record GetNicknameAvailabilityRes(
-        Boolean isAvailable
+        boolean isAvailable
 ) {
-    public static GetNicknameAvailabilityRes from(Boolean isAvailable) {
+    public static GetNicknameAvailabilityRes from(boolean isAvailable) {
         return new GetNicknameAvailabilityRes(isAvailable);
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/repository/UserRepository.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/repository/UserRepository.java
@@ -10,5 +10,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByAppleSub(String appleSub);
 
+    boolean existsByNickname(String nickname);
+
     boolean existsByUserInfoPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -48,7 +48,7 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public Boolean isNicknameUnique(String nickname) {
+    public boolean isNicknameUnique(String nickname) {
         return !userRepository.existsByNickname(nickname);
     }
 

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -3,7 +3,6 @@ package com.econo_4factorial.newproject.user.service;
 import com.econo_4factorial.newproject.auth.dto.apple.AppleUserInfoDTO;
 import com.econo_4factorial.newproject.auth.dto.kakao.KakaoUserInfoDTO;
 import com.econo_4factorial.newproject.user.domain.User;
-import com.econo_4factorial.newproject.user.exeception.BadRequestException.PhoneNumberAlreadyExistsException;
 import com.econo_4factorial.newproject.user.exeception.BadRequestException.UserNotFoundException;
 import com.econo_4factorial.newproject.user.repository.UserRepository;
 import lombok.AllArgsConstructor;
@@ -46,6 +45,11 @@ public class UserService {
     public Boolean isProfileFilled(Long userId) {
         User user = findUserByIdOrThrow(userId);
         return user.isProfileFilled();
+    }
+
+    @Transactional(readOnly = true)
+    public Boolean isNicknameUnique(String nickname) {
+        return !userRepository.existsByNickname(nickname);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.econo_4factorial.newproject.user.service;
 import com.econo_4factorial.newproject.auth.dto.apple.AppleUserInfoDTO;
 import com.econo_4factorial.newproject.auth.dto.kakao.KakaoUserInfoDTO;
 import com.econo_4factorial.newproject.user.domain.User;
+import com.econo_4factorial.newproject.user.exeception.BadRequestException.PhoneNumberAlreadyExistsException;
 import com.econo_4factorial.newproject.user.exeception.BadRequestException.UserNotFoundException;
 import com.econo_4factorial.newproject.user.repository.UserRepository;
 import lombok.AllArgsConstructor;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #128 

## 📝작업 내용

> 닉네임 중복이 있는지 확인하는 기능을 구현했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 컨트롤러, Res, 서비스에서도 Boolean wrapper를 사용했는데, 레포지토리에서는 boolean primitive를 사용했습니다.
레포지토리단에서 무조건 true or false 값이 반환되므로 Null케이스를 고려하지 않아도 되는데.
다른 곳에 있는 Boolean도 primitive로 통일해야하는지, 혹은 wrapper로 통일해야하는지, 아니면 섞어서 써도 되는지 궁금합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 닉네임 중복 검사 엔드포인트 추가 및 사용 가능 여부 반환 기능을 제공합니다.
* **Bug Fixes**
  * 닉네임 필수/길이/패턴 검증 규칙과 DB 수준 고유 제약을 도입해 잘못된 입력과 중복 저장을 방지합니다.
* **Documentation**
  * API에 설명·파라미터 주석(스웨거) 및 응답 구조를 추가해 사용과 확인이 쉬워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->