### PR TITLE
[BE-50] feat : 기본정보 등록 API

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
@@ -5,6 +5,7 @@ public class ValidationMessage {
     public static final String FAMILY_NAME_REQUIRED = "familyName이 누락되었습니다";
     public static final String GIVEN_NAME_REQUIRED = "givenName이 누락되었습니다";
     public static final String EMAIL_PATTERN_INVALID = "email이 올바르지 않은 패턴입니다";
+    public static final String EMAIL_IS_REQUIRED = "email은 필수입니다.";
     public static final String REFRESH_TOKEN_REQUIRED = "refreshToken이 누락되었습니다";
     public static final String COURSE_ID_REQUIRED = "courseId가 누락되었습니다";
     public static final String POSITIVE_NUMBER_REQUIRED = "body의 특정 필드가 양수여야 합니다";

--- a/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.econo_4factorial.newproject.common.util.api.ApiResponse;
 import com.econo_4factorial.newproject.common.util.api.ApiResult;
 import com.econo_4factorial.newproject.user.dto.req.CheckNicknameReq;
 import com.econo_4factorial.newproject.user.dto.res.GetNicknameAvailabilityRes;
+import com.econo_4factorial.newproject.user.dto.req.AddBasicInformationReq;
 import com.econo_4factorial.newproject.user.dto.res.GetProfileStatusRes;
 import com.econo_4factorial.newproject.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,8 +16,8 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @AllArgsConstructor
 @RestController
@@ -40,6 +41,18 @@ public class UserController {
             ) {
         boolean result = userService.isNicknameUnique(checkNicknameReq.nickname());
         return ApiResponse.success(GetNicknameAvailabilityRes.from(result), HttpStatus.OK);
+    }
+
+    @PostMapping("/profile/basic-information")
+    @Operation(summary = "기본정보 등록", description = "사용자의 기본정보(닉네임, 전화번호, 이메일)를 등록합니다.")
+    public ApiResult<ApiResult.SuccessBody<Void>> addBasicInformation (
+            @Parameter(name = "userId", description = "사용자 ID", required = true)
+            @UserId Long userId,
+            @Parameter(name = "basicInformation", description = "사용자 기본정보", required = true)
+            @RequestBody @Valid AddBasicInformationReq addBasicInformationReq
+    ) {
+        userService.registerBasicInformation(userId, addBasicInformationReq);
+        return ApiResponse.success(null, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -45,6 +45,11 @@ public class User extends BaseEntity {
         this.appleSub = appleSub;
     }
 
+    public void registerBasicInformation(String nickname, String phoneNumber, String email) {
+        this.nickname = nickname;
+        this.userInfo.updateBasicInformation(email,phoneNumber);
+    }
+
     public Boolean isProfileFilled() {
         return hasNickname()
                 && hasEmail()

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/vo/UserInfo.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/vo/UserInfo.java
@@ -30,6 +30,11 @@ public class UserInfo {
         this.phoneNumber = null;
     }
 
+    public void updateBasicInformation(String email, String phoneNumber){
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+    }
+
     private void validateEmail(String email) {
         requireNotNullAndNotBlank(email, EMAIL);
         requireValidFormat(VALID_EMAIL_PATTERN, email, EMAIL);

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/vo/UserInfo.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/vo/UserInfo.java
@@ -31,6 +31,8 @@ public class UserInfo {
     }
 
     public void updateBasicInformation(String email, String phoneNumber){
+        validateEmail(email);
+        validatePhoneNumber(phoneNumber);
         this.email = email;
         this.phoneNumber = phoneNumber;
     }

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/req/AddBasicInformationReq.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/req/AddBasicInformationReq.java
@@ -1,0 +1,27 @@
+package com.econo_4factorial.newproject.user.dto.req;
+
+import com.econo_4factorial.newproject.common.annotation.ValidEmailPattern;
+import com.econo_4factorial.newproject.common.exception.ValidationMessage;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record AddBasicInformationReq(
+        @NotNull(message = ValidationMessage.NICKNAME_IS_REQUIRED)
+        @Size(min = 2, max = 12, message = ValidationMessage.NICKNAME_LENGTH_INVALID)
+        @Pattern(
+                regexp = "^[가-힣a-zA-Z0-9]+$",
+                message = ValidationMessage.NICKNAME_PATTERN_INVALID
+        )
+        String nickname,
+        @NotBlank(message = ValidationMessage.PHONE_NUMBER_IS_REQUIRED)
+        @Pattern(
+                regexp = "^010-\\d{4}-\\d{4}$",
+                message = ValidationMessage.PHONE_NUMBER_INVALID
+        )
+        String phoneNumber,
+        @ValidEmailPattern
+        String email
+) {
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/req/AddBasicInformationReq.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/req/AddBasicInformationReq.java
@@ -3,12 +3,11 @@ package com.econo_4factorial.newproject.user.dto.req;
 import com.econo_4factorial.newproject.common.annotation.ValidEmailPattern;
 import com.econo_4factorial.newproject.common.exception.ValidationMessage;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record AddBasicInformationReq(
-        @NotNull(message = ValidationMessage.NICKNAME_IS_REQUIRED)
+        @NotBlank(message = ValidationMessage.NICKNAME_IS_REQUIRED)
         @Size(min = 2, max = 12, message = ValidationMessage.NICKNAME_LENGTH_INVALID)
         @Pattern(
                 regexp = "^[가-힣a-zA-Z0-9]+$",
@@ -21,6 +20,7 @@ public record AddBasicInformationReq(
                 message = ValidationMessage.PHONE_NUMBER_INVALID
         )
         String phoneNumber,
+        @NotBlank(message = ValidationMessage.EMAIL_IS_REQUIRED)
         @ValidEmailPattern
         String email
 ) {

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/req/CheckNicknameReq.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/req/CheckNicknameReq.java
@@ -1,12 +1,12 @@
 package com.econo_4factorial.newproject.user.dto.req;
 
 import com.econo_4factorial.newproject.common.exception.ValidationMessage;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record CheckNicknameReq(
-        @NotNull(message = ValidationMessage.NICKNAME_IS_REQUIRED)
+        @NotBlank(message = ValidationMessage.NICKNAME_IS_REQUIRED)
         @Size(min = 2, max = 12, message = ValidationMessage.NICKNAME_LENGTH_INVALID)
         @Pattern(
                 regexp = "^[가-힣a-zA-Z0-9]+$",

--- a/src/main/java/com/econo_4factorial/newproject/user/exeception/BadRequestException/EmailAlreadyExistsException.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/exeception/BadRequestException/EmailAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package com.econo_4factorial.newproject.user.exeception.BadRequestException;
+
+import com.econo_4factorial.newproject.common.exception.BadRequestException;
+import com.econo_4factorial.newproject.user.exeception.UserErrorType;
+
+public class EmailAlreadyExistsException extends BadRequestException {
+    public EmailAlreadyExistsException() {
+        super(UserErrorType.EMAIL_ALREADY_EXISTS_EXCEPTION);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/exeception/UserErrorType.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/exeception/UserErrorType.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum UserErrorType implements ErrorType {
     USER_NOT_FOUND_EXCEPTION ("USER400_001", HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다"),
-    PHONE_NUMBER_ALREADY_EXISTS_EXCEPTION("USER400_002", HttpStatus.BAD_REQUEST, "이미 존재하는 전화번호입니다.");
+    PHONE_NUMBER_ALREADY_EXISTS_EXCEPTION("USER400_002", HttpStatus.BAD_REQUEST, "이미 존재하는 전화번호입니다."),
+    EMAIL_ALREADY_EXISTS_EXCEPTION("USER400_003", HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다.");
 
     private final String errorCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/econo_4factorial/newproject/user/repository/UserRepository.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     boolean existsByUserInfoPhoneNumber(String phoneNumber);
+
+    boolean existsByUserInfoEmail(String email);
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -64,11 +64,16 @@ public class UserService {
         }
     }
 
-    @Transactional
-    public void registerBasicInformation(Long userId, AddBasicInformationReq addBasicInformationReq) {
-        if(userRepository.existsByUserInfoEmail(addBasicInformationReq.email())){
+    @Transactional(readOnly = true)
+    public void validateExistEmail(String email) {
+        if(userRepository.existsByUserInfoEmail(email)) {
             throw new EmailAlreadyExistsException();
         }
+    }
+
+    @Transactional
+    public void registerBasicInformation(Long userId, AddBasicInformationReq addBasicInformationReq) {
+        validateExistEmail(addBasicInformationReq.email());
         User user = findUserByIdOrThrow(userId);
         user.registerBasicInformation(addBasicInformationReq.nickname(), addBasicInformationReq.phoneNumber(), addBasicInformationReq.email());
     }

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.econo_4factorial.newproject.user.service;
 import com.econo_4factorial.newproject.auth.dto.apple.AppleUserInfoDTO;
 import com.econo_4factorial.newproject.auth.dto.kakao.KakaoUserInfoDTO;
 import com.econo_4factorial.newproject.user.domain.User;
+import com.econo_4factorial.newproject.user.dto.req.AddBasicInformationReq;
+import com.econo_4factorial.newproject.user.exeception.BadRequestException.EmailAlreadyExistsException;
 import com.econo_4factorial.newproject.user.exeception.BadRequestException.PhoneNumberAlreadyExistsException;
 import com.econo_4factorial.newproject.user.exeception.BadRequestException.UserNotFoundException;
 import com.econo_4factorial.newproject.user.repository.UserRepository;
@@ -15,7 +17,9 @@ import static com.econo_4factorial.newproject.user.mapper.UserMapper.toEntity;
 @Service
 @AllArgsConstructor
 public class UserService {
+
     private final UserRepository userRepository;
+
     @Transactional(readOnly = true)
     public User findUserByIdOrThrow(Long userId) {
         return userRepository.findById(userId)
@@ -58,5 +62,14 @@ public class UserService {
         if(userRepository.existsByUserInfoPhoneNumber(phoneNumber)) {
             throw new PhoneNumberAlreadyExistsException();
         }
+    }
+
+    @Transactional
+    public void registerBasicInformation(Long userId, AddBasicInformationReq addBasicInformationReq) {
+        if(userRepository.existsByUserInfoEmail(addBasicInformationReq.email())){
+            throw new EmailAlreadyExistsException();
+        }
+        User user = findUserByIdOrThrow(userId);
+        user.registerBasicInformation(addBasicInformationReq.nickname(), addBasicInformationReq.phoneNumber(), addBasicInformationReq.email());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #127 

## 📝작업 내용

> 사용자 요청 dto의 유효성 검사 후, 이메일 중복 검사를 진행합니다.
이메일이 중복일 경우 예외를 그렇지 않으면 기본정보를 등록합니다.
전화번호 중복검사는 SMS 인증시 수행하므로 해당 API에서는 수행하지 않습니다.

### 스크린샷 (선택)
<img width="2804" height="1176" alt="image" src="https://github.com/user-attachments/assets/90673858-eae3-41cc-a2a9-579b9b47273e" />

<img width="1217" height="129" alt="image" src="https://github.com/user-attachments/assets/f604fac6-2191-47a9-9676-686aa4d0be98" />


## 💬리뷰 요구사항(선택)

> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 프로필 기본정보 등록 API 추가(POST /profile/basic-information): 닉네임, 휴대전화, 이메일 등록 지원
  * 이메일 중복 검사 및 중복 시 오류 반환

* **유효성 검사**
  * 닉네임: 비어있음 차단, 길이/패턴 검증 유지
  * 휴대전화 형식(010-xxxx-xxxx) 검증 유지
  * 이메일: 필수 및 형식 검증 강화

* **문서**
  * 신규 엔드포인트에 대한 API 문서 및 파라미터 설명 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->