### PR TITLE
[BE-60] feat: 알림 설정값 조회 등록 기능 구현

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
@@ -16,7 +16,7 @@ public class ValidationMessage {
     public static final String PHONE_NUMBER_INVALID = "전화번호 형식이 올바르지 않습니다.";
     public static final String VERIFICATION_CODE_IS_REQUIRED = "인증번호는 필수입니다.";
     public static final String VERIFICATION_CODE_INVALID = "인증번호 형식이 올바르지 않습니다.";
-    public static final String EVENT_ALERT_IS_REQUIRED = "eventAlert 는 필수입니다.";
+    public static final String EVENT_ALERT_IS_REQUIRED = "eventAlert는 필수입니다.";
     public static final String TRAVEL_DEVIATION_ALERT_IS_REQUIRED = "travelDeviationAlert 는 필수입니다.";
     public static final String ACCIDENT_PRONE_AREA_ALERT_IS_REQUIRED = "accidentProneAreaAlert 는 필수입니다.";
 }

--- a/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/exception/ValidationMessage.java
@@ -16,4 +16,7 @@ public class ValidationMessage {
     public static final String PHONE_NUMBER_INVALID = "전화번호 형식이 올바르지 않습니다.";
     public static final String VERIFICATION_CODE_IS_REQUIRED = "인증번호는 필수입니다.";
     public static final String VERIFICATION_CODE_INVALID = "인증번호 형식이 올바르지 않습니다.";
+    public static final String EVENT_ALERT_IS_REQUIRED = "eventAlert 는 필수입니다.";
+    public static final String TRAVEL_DEVIATION_ALERT_IS_REQUIRED = "travelDeviationAlert 는 필수입니다.";
+    public static final String ACCIDENT_PRONE_AREA_ALERT_IS_REQUIRED = "accidentProneAreaAlert 는 필수입니다.";
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
@@ -3,7 +3,9 @@ package com.econo_4factorial.newproject.user.controller;
 import com.econo_4factorial.newproject.common.annotation.UserId;
 import com.econo_4factorial.newproject.common.util.api.ApiResponse;
 import com.econo_4factorial.newproject.common.util.api.ApiResult;
+import com.econo_4factorial.newproject.user.dto.UserAlertSettingDTO;
 import com.econo_4factorial.newproject.user.dto.req.CheckNicknameReq;
+import com.econo_4factorial.newproject.user.dto.res.GetAlertSettingRes;
 import com.econo_4factorial.newproject.user.dto.res.GetNicknameAvailabilityRes;
 import com.econo_4factorial.newproject.user.dto.req.AddBasicInformationReq;
 import com.econo_4factorial.newproject.user.dto.res.GetProfileStatusRes;
@@ -17,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.*;
 
 @AllArgsConstructor
@@ -54,5 +57,18 @@ public class UserController {
         userService.registerBasicInformation(userId, addBasicInformationReq);
         return ApiResponse.success(null, HttpStatus.OK);
     }
+
+    @GetMapping("/alert")
+    @Operation(summary = "알림 설정값 조회", description = "사용자 알림 설정값을 조회합니다.")
+    public ApiResult<ApiResult.SuccessBody<GetAlertSettingRes>> getAlert(
+            @Parameter(name = "userId", description = "유저 아이디", required = true)
+            @UserId Long userId
+    ) {
+        UserAlertSettingDTO userAlertSettingDTO = userService.getUserAlertSetting(userId);
+        return ApiResponse.success(GetAlertSettingRes.from(userAlertSettingDTO),HttpStatus.OK);
+    }
+
+//    @PutMapping("/alert")
+//    @Operation(summary = "알림 설정값 등록", description = "사용자 알림 설정값을 등록(설정)합니다.")
 
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.econo_4factorial.newproject.common.annotation.UserId;
 import com.econo_4factorial.newproject.common.util.api.ApiResponse;
 import com.econo_4factorial.newproject.common.util.api.ApiResult;
 import com.econo_4factorial.newproject.user.dto.UserAlertSettingDTO;
+import com.econo_4factorial.newproject.user.dto.req.AlertSettingReq;
 import com.econo_4factorial.newproject.user.dto.req.CheckNicknameReq;
 import com.econo_4factorial.newproject.user.dto.res.GetAlertSettingRes;
 import com.econo_4factorial.newproject.user.dto.res.GetNicknameAvailabilityRes;
@@ -68,7 +69,15 @@ public class UserController {
         return ApiResponse.success(GetAlertSettingRes.from(userAlertSettingDTO),HttpStatus.OK);
     }
 
-//    @PutMapping("/alert")
-//    @Operation(summary = "알림 설정값 등록", description = "사용자 알림 설정값을 등록(설정)합니다.")
+    @PutMapping("/alert")
+    @Operation(summary = "알림 설정값 등록", description = "사용자 알림 설정값을 등록(설정)합니다.")
+    public ApiResult<ApiResult.SuccessBody<Void>> updateAlert(
+            @Parameter(name = "userId", description = "유저 아이디", required = true)
+            @UserId Long userId,
+            @RequestBody @Valid AlertSettingReq alertSettingReq
+    ) {
+        userService.updateAlertSetting(userId, alertSettingReq);
+        return ApiResponse.success(null, HttpStatus.OK);
+    }
 
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.bind.annotation.*;
 
 @AllArgsConstructor
 @RestController

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -54,10 +54,8 @@ public class User extends BaseEntity {
         this.userInfo.updateBasicInformation(email,phoneNumber);
     }
 
-    public void updateAlerts(boolean eventAlert, boolean travelDeviationAlert, boolean accidentProneAreaAlert) {
-        this.eventAlert = eventAlert;
-        this.travelDeviationAlert = travelDeviationAlert;
-        this.accidentProneAreaAlert = accidentProneAreaAlert;
+    public void updateUserAlert(boolean eventAlert, boolean travelDeviationAlert, boolean accidentProneAreaAlert) {
+        userAlert.updateAlerts(eventAlert, travelDeviationAlert, accidentProneAreaAlert);
     }
 
     public Boolean isProfileFilled() {

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -35,7 +35,7 @@ public class User extends BaseEntity {
     private String nickname;
 
     @Embedded
-    private UserAlert userAlert;
+    private UserAlert userAlert = new UserAlert();
 
     @Builder(builderMethodName = "kakaoUserBuilder", builderClassName = "kakaoUserBuilder")
     public User(String email, String name, Long kakaoId) {

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.econo_4factorial.newproject.user.domain;
 
 import com.econo_4factorial.newproject.common.entity.BaseEntity;
+import com.econo_4factorial.newproject.user.domain.vo.UserAlert;
 import com.econo_4factorial.newproject.user.domain.vo.UserInfo;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -33,14 +34,8 @@ public class User extends BaseEntity {
     @Column(unique = true)
     private String nickname;
 
-    @Column(nullable = false)
-    private boolean eventAlert = true;
-
-    @Column(nullable = false)
-    private boolean travelDeviationAlert = true;
-
-    @Column(nullable = false)
-    private boolean accidentProneAreaAlert = true;
+    @Embedded
+    private UserAlert userAlert;
 
     @Builder(builderMethodName = "kakaoUserBuilder", builderClassName = "kakaoUserBuilder")
     public User(String email, String name, Long kakaoId) {

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -33,6 +33,15 @@ public class User extends BaseEntity {
     @Column(unique = true)
     private String nickname;
 
+    @Column(nullable = false)
+    private boolean eventAlert = true;
+
+    @Column(nullable = false)
+    private boolean travelDeviationAlert = true;
+
+    @Column(nullable = false)
+    private boolean accidentProneAreaAlert = true;
+
     @Builder(builderMethodName = "kakaoUserBuilder", builderClassName = "kakaoUserBuilder")
     public User(String email, String name, Long kakaoId) {
         this.userInfo = new UserInfo(email, name);

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -59,6 +59,12 @@ public class User extends BaseEntity {
         this.userInfo.updateBasicInformation(email,phoneNumber);
     }
 
+    public void updateAlerts(boolean event, boolean travel, boolean accident) {
+        this.eventAlert = event;
+        this.travelDeviationAlert = travel;
+        this.accidentProneAreaAlert = accident;
+    }
+
     public Boolean isProfileFilled() {
         return hasNickname()
                 && hasEmail()

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -59,10 +59,10 @@ public class User extends BaseEntity {
         this.userInfo.updateBasicInformation(email,phoneNumber);
     }
 
-    public void updateAlerts(boolean event, boolean travel, boolean accident) {
-        this.eventAlert = event;
-        this.travelDeviationAlert = travel;
-        this.accidentProneAreaAlert = accident;
+    public void updateAlerts(boolean eventAlert, boolean travelDeviationAlert, boolean accidentProneAreaAlert) {
+        this.eventAlert = eventAlert;
+        this.travelDeviationAlert = travelDeviationAlert;
+        this.accidentProneAreaAlert = accidentProneAreaAlert;
     }
 
     public Boolean isProfileFilled() {

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/vo/UserAlert.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/vo/UserAlert.java
@@ -1,0 +1,29 @@
+package com.econo_4factorial.newproject.user.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class UserAlert {
+
+    @Column(name = "event_alert", nullable = false)
+    private boolean eventAlert = true;
+
+    @Column(name = "travel_deviation_alert", nullable = false)
+    private boolean travelDeviationAlert = true;
+
+    @Column(name = "accident_prone_area_alert", nullable = false)
+    private boolean accidentProneAreaAlert = true;
+
+    public void updateAlerts(boolean eventAlert, boolean travelDeviationAlert, boolean accidentProneAreaAlert) {
+        this.eventAlert = eventAlert;
+        this.travelDeviationAlert = travelDeviationAlert;
+        this.accidentProneAreaAlert = accidentProneAreaAlert;
+    }
+
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/vo/UserAlert.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/vo/UserAlert.java
@@ -2,12 +2,11 @@ package com.econo_4factorial.newproject.user.domain.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @Getter
 public class UserAlert {
 

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/UserAlertSettingDTO.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/UserAlertSettingDTO.java
@@ -1,17 +1,18 @@
 package com.econo_4factorial.newproject.user.dto;
 
 import com.econo_4factorial.newproject.user.domain.User;
+import com.econo_4factorial.newproject.user.domain.vo.UserAlert;
 
 public record UserAlertSettingDTO(
         boolean eventAlert,
         boolean travelDeviationAlert,
         boolean accidentProneAreaAlert
 ) {
-    public static UserAlertSettingDTO from(User user) {
+    public static UserAlertSettingDTO from(UserAlert userAlert) {
         return new UserAlertSettingDTO(
-                user.getUserAlert().isEventAlert(),
-                user.getUserAlert().isTravelDeviationAlert(),
-                user.getUserAlert().isAccidentProneAreaAlert()
+                userAlert.isEventAlert(),
+                userAlert.isTravelDeviationAlert(),
+                userAlert.isAccidentProneAreaAlert()
         );
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/UserAlertSettingDTO.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/UserAlertSettingDTO.java
@@ -1,0 +1,17 @@
+package com.econo_4factorial.newproject.user.dto;
+
+import com.econo_4factorial.newproject.user.domain.User;
+
+public record UserAlertSettingDTO(
+        boolean eventAlert,
+        boolean travelDeviationAlert,
+        boolean accidentProneAreaAlert
+) {
+    public static UserAlertSettingDTO from(User user) {
+        return new UserAlertSettingDTO(
+                user.isEventAlert(),
+                user.isTravelDeviationAlert(),
+                user.isAccidentProneAreaAlert()
+        );
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/UserAlertSettingDTO.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/UserAlertSettingDTO.java
@@ -9,9 +9,9 @@ public record UserAlertSettingDTO(
 ) {
     public static UserAlertSettingDTO from(User user) {
         return new UserAlertSettingDTO(
-                user.isEventAlert(),
-                user.isTravelDeviationAlert(),
-                user.isAccidentProneAreaAlert()
+                user.getUserAlert().isEventAlert(),
+                user.getUserAlert().isTravelDeviationAlert(),
+                user.getUserAlert().isAccidentProneAreaAlert()
         );
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/req/AlertSettingReq.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/req/AlertSettingReq.java
@@ -1,0 +1,14 @@
+package com.econo_4factorial.newproject.user.dto.req;
+
+import com.econo_4factorial.newproject.common.exception.ValidationMessage;
+import jakarta.validation.constraints.NotNull;
+
+public record AlertSettingReq(
+        @NotNull(message = ValidationMessage.EVENT_ALERT_IS_REQUIRED)
+        Boolean eventAlert,
+        @NotNull(message = ValidationMessage.TRAVEL_DEVIATION_ALERT_IS_REQUIRED)
+        Boolean travelDeviationAlert,
+        @NotNull(message = ValidationMessage.ACCIDENT_PRONE_AREA_ALERT_IS_REQUIRED)
+        Boolean accidentProneAreaAlert
+) {
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/res/GetAlertSettingRes.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/res/GetAlertSettingRes.java
@@ -1,0 +1,11 @@
+package com.econo_4factorial.newproject.user.dto.res;
+
+import com.econo_4factorial.newproject.user.dto.UserAlertSettingDTO;
+
+public record GetAlertSettingRes(
+        UserAlertSettingDTO userAlertSetting
+) {
+    public static GetAlertSettingRes from (UserAlertSettingDTO userAlertSetting) {
+        return new GetAlertSettingRes(userAlertSetting);
+    }
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -87,18 +87,17 @@ public class UserService {
     public UserAlertSettingDTO getUserAlertSetting(Long userId) {
         return userRepository.findById(userId)
                 .map(user -> new UserAlertSettingDTO(
-                        user.isEventAlert(),
-                        user.isTravelDeviationAlert(),
-                        user.isAccidentProneAreaAlert()
+                        user.getUserAlert().isEventAlert(),
+                        user.getUserAlert().isTravelDeviationAlert(),
+                        user.getUserAlert().isAccidentProneAreaAlert()
                 ))
                 .orElseThrow(UserNotFoundException::new);
-
     }
 
     @Transactional
     public void updateAlertSetting(Long userId, AlertSettingReq alertSettingReq) {
         User user = findUserByIdOrThrow(userId);
-        user.updateAlerts(
+        user.getUserAlert().updateAlerts(
                 alertSettingReq.eventAlert(),
                 alertSettingReq.travelDeviationAlert(),
                 alertSettingReq.accidentProneAreaAlert()

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -5,7 +5,6 @@ import com.econo_4factorial.newproject.auth.dto.kakao.KakaoUserInfoDTO;
 import com.econo_4factorial.newproject.user.domain.User;
 import com.econo_4factorial.newproject.user.dto.UserAlertSettingDTO;
 import com.econo_4factorial.newproject.user.dto.req.AlertSettingReq;
-import com.econo_4factorial.newproject.user.dto.res.GetAlertSettingRes;
 import com.econo_4factorial.newproject.user.dto.req.AddBasicInformationReq;
 import com.econo_4factorial.newproject.user.exeception.BadRequestException.EmailAlreadyExistsException;
 import com.econo_4factorial.newproject.user.exeception.BadRequestException.PhoneNumberAlreadyExistsException;

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.econo_4factorial.newproject.user.service;
 import com.econo_4factorial.newproject.auth.dto.apple.AppleUserInfoDTO;
 import com.econo_4factorial.newproject.auth.dto.kakao.KakaoUserInfoDTO;
 import com.econo_4factorial.newproject.user.domain.User;
+import com.econo_4factorial.newproject.user.dto.UserAlertSettingDTO;
+import com.econo_4factorial.newproject.user.dto.res.GetAlertSettingRes;
 import com.econo_4factorial.newproject.user.dto.req.AddBasicInformationReq;
 import com.econo_4factorial.newproject.user.exeception.BadRequestException.EmailAlreadyExistsException;
 import com.econo_4factorial.newproject.user.exeception.BadRequestException.PhoneNumberAlreadyExistsException;
@@ -11,6 +13,8 @@ import com.econo_4factorial.newproject.user.repository.UserRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 import static com.econo_4factorial.newproject.user.mapper.UserMapper.toEntity;
 
@@ -76,5 +80,17 @@ public class UserService {
         validateExistEmail(addBasicInformationReq.email());
         User user = findUserByIdOrThrow(userId);
         user.registerBasicInformation(addBasicInformationReq.nickname(), addBasicInformationReq.phoneNumber(), addBasicInformationReq.email());
+    }
+
+    @Transactional(readOnly = true)
+    public UserAlertSettingDTO getUserAlertSetting(Long userId) {
+        return userRepository.findById(userId)
+                .map(user -> new UserAlertSettingDTO(
+                        user.isEventAlert(),
+                        user.isTravelDeviationAlert(),
+                        user.isAccidentProneAreaAlert()
+                ))
+                .orElseThrow(UserNotFoundException::new);
+
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.econo_4factorial.newproject.auth.dto.apple.AppleUserInfoDTO;
 import com.econo_4factorial.newproject.auth.dto.kakao.KakaoUserInfoDTO;
 import com.econo_4factorial.newproject.user.domain.User;
 import com.econo_4factorial.newproject.user.dto.UserAlertSettingDTO;
+import com.econo_4factorial.newproject.user.dto.req.AlertSettingReq;
 import com.econo_4factorial.newproject.user.dto.res.GetAlertSettingRes;
 import com.econo_4factorial.newproject.user.dto.req.AddBasicInformationReq;
 import com.econo_4factorial.newproject.user.exeception.BadRequestException.EmailAlreadyExistsException;
@@ -92,5 +93,15 @@ public class UserService {
                 ))
                 .orElseThrow(UserNotFoundException::new);
 
+    }
+
+    @Transactional
+    public void updateAlertSetting(Long userId, AlertSettingReq alertSettingReq) {
+        User user = findUserByIdOrThrow(userId);
+        user.updateAlerts(
+                alertSettingReq.eventAlert(),
+                alertSettingReq.travelDeviationAlert(),
+                alertSettingReq.accidentProneAreaAlert()
+        );
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -91,9 +91,9 @@ public class UserService {
     public void updateAlertSetting(Long userId, AlertSettingReq alertSettingReq) {
         User user = findUserByIdOrThrow(userId);
         user.getUserAlert().updateAlerts(
-                alertSettingReq.eventAlert(),
-                alertSettingReq.travelDeviationAlert(),
-                alertSettingReq.accidentProneAreaAlert()
+                Boolean.TRUE.equals(alertSettingReq.eventAlert()),
+                Boolean.TRUE.equals(alertSettingReq.travelDeviationAlert()),
+                Boolean.TRUE.equals(alertSettingReq.accidentProneAreaAlert())
         );
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -84,13 +84,13 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserAlertSettingDTO getUserAlertSetting(Long userId) {
         User user = findUserByIdOrThrow(userId);
-        return UserAlertSettingDTO.from(user);
+        return UserAlertSettingDTO.from(user.getUserAlert());
     }
 
     @Transactional
     public void updateAlertSetting(Long userId, AlertSettingReq alertSettingReq) {
         User user = findUserByIdOrThrow(userId);
-        user.getUserAlert().updateAlerts(
+        user.updateUserAlert(
                 Boolean.TRUE.equals(alertSettingReq.eventAlert()),
                 Boolean.TRUE.equals(alertSettingReq.travelDeviationAlert()),
                 Boolean.TRUE.equals(alertSettingReq.accidentProneAreaAlert())

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -15,8 +15,6 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 import static com.econo_4factorial.newproject.user.mapper.UserMapper.toEntity;
 
 @Service
@@ -85,13 +83,8 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserAlertSettingDTO getUserAlertSetting(Long userId) {
-        return userRepository.findById(userId)
-                .map(user -> new UserAlertSettingDTO(
-                        user.getUserAlert().isEventAlert(),
-                        user.getUserAlert().isTravelDeviationAlert(),
-                        user.getUserAlert().isAccidentProneAreaAlert()
-                ))
-                .orElseThrow(UserNotFoundException::new);
+        User user = findUserByIdOrThrow(userId);
+        return UserAlertSettingDTO.from(user);
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

> #148 

## 📝작업 내용

> 알림 설정값 조회 및 등록 기능을 구현했습니다.
알림 설정 여부(boolean)을 저장하는 값을 VO를 이용해 구현했습니다.

### 스크린샷 (선택)

<img width="3420" height="482" alt="image" src="https://github.com/user-attachments/assets/d1c7ba12-3d41-4a7b-b245-f36155087bd1" />


## 💬리뷰 요구사항(선택)

> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 알림 설정 관리 기능 추가: 이벤트 알림, 이동 이탈 알림, 사고 다발 지역 알림을 개별로 켜고 끌 수 있습니다(기본값: 활성화).
  - 알림 설정 조회 API 추가: 현재 사용자의 알림 설정을 반환합니다.
  - 알림 설정 수정 API 추가: 사용자가 설정을 업데이트할 수 있습니다.
  - 요청 유효성 검사 강화: 각 알림 필드 누락 시 명확한 검증 메시지를 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->