### PR TITLE
[BE-59] feat: 개인정보 설정 여부 추가

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
@@ -4,7 +4,7 @@ import com.econo_4factorial.newproject.common.annotation.UserId;
 import com.econo_4factorial.newproject.common.util.api.ApiResponse;
 import com.econo_4factorial.newproject.common.util.api.ApiResult;
 import com.econo_4factorial.newproject.user.dto.UserAlertSettingDTO;
-import com.econo_4factorial.newproject.user.dto.UserStatusInfoDTO;
+import com.econo_4factorial.newproject.user.dto.ProfileStatusInfoDTO;
 import com.econo_4factorial.newproject.user.dto.req.AddPersonalInformationReq;
 import com.econo_4factorial.newproject.user.dto.req.AlertSettingReq;
 import com.econo_4factorial.newproject.user.dto.req.CheckNicknameReq;
@@ -36,8 +36,8 @@ public class UserController {
     public ApiResult<ApiResult.SuccessBody<GetProfileStatusRes>> getProfileStatus (
             @Parameter(hidden = true)
             @UserId Long userId) {
-        UserStatusInfoDTO userStatusInfoDTO = userService.isProfileSet(userId);
-        return ApiResponse.success(GetProfileStatusRes.from(userStatusInfoDTO), HttpStatus.OK);
+        ProfileStatusInfoDTO profileStatusInfoDTO = userService.isProfileSet(userId);
+        return ApiResponse.success(GetProfileStatusRes.from(profileStatusInfoDTO), HttpStatus.OK);
     }
 
     @GetMapping("/nickname/check")

--- a/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.econo_4factorial.newproject.common.annotation.UserId;
 import com.econo_4factorial.newproject.common.util.api.ApiResponse;
 import com.econo_4factorial.newproject.common.util.api.ApiResult;
 import com.econo_4factorial.newproject.user.dto.UserAlertSettingDTO;
+import com.econo_4factorial.newproject.user.dto.UserStatusInfoDTO;
 import com.econo_4factorial.newproject.user.dto.req.AddPersonalInformationReq;
 import com.econo_4factorial.newproject.user.dto.req.AlertSettingReq;
 import com.econo_4factorial.newproject.user.dto.req.CheckNicknameReq;
@@ -33,8 +34,8 @@ public class UserController {
     @GetMapping("/profile/status")
     @Operation(summary = "프로필 설정 여부 확인", description = "프로필 설정(기본정보/개인정보) 여부 값을 반환합니다.")
     public ApiResult<ApiResult.SuccessBody<GetProfileStatusRes>> getProfileStatus (@UserId Long userId) {
-        Boolean result = userService.isProfileFilled(userId);
-        return ApiResponse.success(GetProfileStatusRes.from(result), HttpStatus.OK);
+        UserStatusInfoDTO userStatusInfoDTO = userService.isProfileSet(userId);
+        return ApiResponse.success(GetProfileStatusRes.from(userStatusInfoDTO), HttpStatus.OK);
     }
 
     @GetMapping("/nickname/check")

--- a/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/controller/UserController.java
@@ -33,7 +33,9 @@ public class UserController {
 
     @GetMapping("/profile/status")
     @Operation(summary = "프로필 설정 여부 확인", description = "프로필 설정(기본정보/개인정보) 여부 값을 반환합니다.")
-    public ApiResult<ApiResult.SuccessBody<GetProfileStatusRes>> getProfileStatus (@UserId Long userId) {
+    public ApiResult<ApiResult.SuccessBody<GetProfileStatusRes>> getProfileStatus (
+            @Parameter(hidden = true)
+            @UserId Long userId) {
         UserStatusInfoDTO userStatusInfoDTO = userService.isProfileSet(userId);
         return ApiResponse.success(GetProfileStatusRes.from(userStatusInfoDTO), HttpStatus.OK);
     }

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -68,25 +68,10 @@ public class User extends BaseEntity {
     }
 
     public boolean isBasicInfoSet() {
-        return hasNickname()
-                && hasEmail()
-                && hasPhoneNumber();
+        return nickname != null && userInfo.isBasicInfoSet();
     }
 
     public boolean isPersonalInfoSet() {
         return physicalInfo != null && physicalInfo.isPersonalInfoSet();
     }
-
-    private boolean hasNickname() {
-        return this.nickname != null;
-    }
-
-    private boolean hasEmail() {
-        return this.userInfo.getEmail() != null;
-    }
-
-    private boolean hasPhoneNumber() {
-        return this.userInfo.getPhoneNumber() != null;
-    }
-
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -74,10 +74,7 @@ public class User extends BaseEntity {
     }
 
     public boolean isPersonalInfoSet() {
-        if (physicalInfo == null) {
-            return false;
-        }
-        return hasWeight() && hasHeight() && hasBloodType();
+        return physicalInfo != null && physicalInfo.isPersonalInfoSet();
     }
 
     private boolean hasNickname() {
@@ -90,18 +87,6 @@ public class User extends BaseEntity {
 
     private boolean hasPhoneNumber() {
         return this.userInfo.getPhoneNumber() != null;
-    }
-
-    private boolean hasWeight() {
-        return physicalInfo != null && physicalInfo.getWeight() != null;
-    }
-
-    private boolean hasHeight() {
-        return physicalInfo != null && physicalInfo.getHeight() != null;
-    }
-
-    private boolean hasBloodType() {
-        return physicalInfo != null && physicalInfo.getBloodType() != null;
     }
 
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -77,9 +77,7 @@ public class User extends BaseEntity {
         if (physicalInfo == null) {
             return false;
         }
-        return hasWeight()
-                && hasHeight()
-                && hasBloodType();
+        return hasWeight() && hasHeight() && hasBloodType();
     }
 
     private boolean hasNickname() {
@@ -95,15 +93,15 @@ public class User extends BaseEntity {
     }
 
     private boolean hasWeight() {
-        return physicalInfo.getWeight() != null;
+        return physicalInfo != null && physicalInfo.getWeight() != null;
     }
 
     private boolean hasHeight() {
-        return physicalInfo.getHeight() != null;
+        return physicalInfo != null && physicalInfo.getHeight() != null;
     }
 
     private boolean hasBloodType() {
-        return physicalInfo.getBloodType() != null;
+        return physicalInfo != null && physicalInfo.getBloodType() != null;
     }
 
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -73,6 +73,12 @@ public class User extends BaseEntity {
                 && hasPhoneNumber();
     }
 
+    public boolean isPersonalInfoSet() {
+        return hasWeight()
+                && hasHeight()
+                && hasBloodType();
+    }
+
     private boolean hasNickname() {
         return this.nickname != null;
     }
@@ -83,6 +89,18 @@ public class User extends BaseEntity {
 
     private boolean hasPhoneNumber() {
         return this.userInfo.getPhoneNumber() != null;
+    }
+
+    private boolean hasWeight() {
+        return physicalInfo.getWeight() != null;
+    }
+
+    private boolean hasHeight() {
+        return physicalInfo.getHeight() != null;
+    }
+
+    private boolean hasBloodType() {
+        return physicalInfo.getBloodType() != null;
     }
 
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -74,6 +74,9 @@ public class User extends BaseEntity {
     }
 
     public boolean isPersonalInfoSet() {
+        if (physicalInfo == null) {
+            return false;
+        }
         return hasWeight()
                 && hasHeight()
                 && hasBloodType();

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/User.java
@@ -67,13 +67,13 @@ public class User extends BaseEntity {
         userAlert.updateAlerts(eventAlert, travelDeviationAlert, accidentProneAreaAlert);
     }
 
-    public Boolean isProfileFilled() {
+    public boolean isBasicInfoSet() {
         return hasNickname()
                 && hasEmail()
                 && hasPhoneNumber();
     }
 
-    private Boolean hasNickname() {
+    private boolean hasNickname() {
         return this.nickname != null;
     }
 

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/vo/PhysicalInfo.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/vo/PhysicalInfo.java
@@ -34,4 +34,8 @@ public class PhysicalInfo {
         this.height = height;
         this.bloodType = bloodType;
     }
+
+    public boolean isPersonalInfoSet() {
+        return weight != null && height != null && bloodType != null;
+    }
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/domain/vo/UserInfo.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/domain/vo/UserInfo.java
@@ -68,4 +68,8 @@ public class UserInfo {
             throw new IllegalArgumentException(fieldName + "값은 올바르지 않은 형태입니다");
     }
 
+    public boolean isBasicInfoSet() {
+        return email != null && phoneNumber != null;
+    }
+
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/ProfileStatusInfoDTO.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/ProfileStatusInfoDTO.java
@@ -1,6 +1,6 @@
 package com.econo_4factorial.newproject.user.dto;
 
-public record UserStatusInfoDTO(
+public record ProfileStatusInfoDTO(
         boolean isBasicInfoSet,
         boolean isPersonalInfoSet
 ) {

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/UserStatusInfoDTO.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/UserStatusInfoDTO.java
@@ -1,0 +1,7 @@
+package com.econo_4factorial.newproject.user.dto;
+
+public record UserStatusInfoDTO(
+        boolean isBasicInfoSet,
+        boolean isPersonalInfoSet
+) {
+}

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/res/GetProfileStatusRes.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/res/GetProfileStatusRes.java
@@ -1,12 +1,11 @@
 package com.econo_4factorial.newproject.user.dto.res;
 
-import com.econo_4factorial.newproject.user.dto.UserInfoDTO;
-import com.econo_4factorial.newproject.user.dto.UserStatusInfoDTO;
+import com.econo_4factorial.newproject.user.dto.ProfileStatusInfoDTO;
 
 public record GetProfileStatusRes(
-        UserStatusInfoDTO userStatusInfoDTO
+        ProfileStatusInfoDTO profileStatusInfoDTO
 ) {
-    public static GetProfileStatusRes from (UserStatusInfoDTO userStatusInfoDTO) {
-        return new GetProfileStatusRes(userStatusInfoDTO);
+    public static GetProfileStatusRes from (ProfileStatusInfoDTO profileStatusInfoDTO) {
+        return new GetProfileStatusRes(profileStatusInfoDTO);
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/dto/res/GetProfileStatusRes.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/dto/res/GetProfileStatusRes.java
@@ -1,9 +1,12 @@
 package com.econo_4factorial.newproject.user.dto.res;
 
+import com.econo_4factorial.newproject.user.dto.UserInfoDTO;
+import com.econo_4factorial.newproject.user.dto.UserStatusInfoDTO;
+
 public record GetProfileStatusRes(
-        Boolean isComplete
+        UserStatusInfoDTO userStatusInfoDTO
 ) {
-    public static GetProfileStatusRes from (Boolean bool) {
-        return new GetProfileStatusRes(bool);
+    public static GetProfileStatusRes from (UserStatusInfoDTO userStatusInfoDTO) {
+        return new GetProfileStatusRes(userStatusInfoDTO);
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -53,19 +53,10 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public ProfileStatusInfoDTO isProfileSet(Long userId) {
-        boolean basicInfo = isBasicInfoSet(userId);
-        boolean personalInfo = isPersonalInfoSet(userId);
+        User user = findUserByIdOrThrow(userId);
+        boolean basicInfo = user.isBasicInfoSet();
+        boolean personalInfo = user.isPersonalInfoSet();
         return new ProfileStatusInfoDTO(basicInfo, personalInfo);
-    }
-
-    private Boolean isBasicInfoSet(Long userId) {
-        User user = findUserByIdOrThrow(userId);
-        return user.isBasicInfoSet();
-    }
-
-    private Boolean isPersonalInfoSet(Long userId) {
-        User user = findUserByIdOrThrow(userId);
-        return user.isPersonalInfoSet();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -2,15 +2,14 @@ package com.econo_4factorial.newproject.user.service;
 
 import com.econo_4factorial.newproject.auth.dto.apple.AppleUserInfoDTO;
 import com.econo_4factorial.newproject.auth.dto.kakao.KakaoUserInfoDTO;
-import com.econo_4factorial.newproject.common.exception.BadRequestException;
 import com.econo_4factorial.newproject.user.domain.BloodType;
 import com.econo_4factorial.newproject.user.domain.User;
 import com.econo_4factorial.newproject.user.dto.UserAlertSettingDTO;
+import com.econo_4factorial.newproject.user.dto.UserStatusInfoDTO;
 import com.econo_4factorial.newproject.user.dto.req.AddPersonalInformationReq;
 import com.econo_4factorial.newproject.user.dto.req.AlertSettingReq;
 import com.econo_4factorial.newproject.user.dto.req.AddBasicInformationReq;
 import com.econo_4factorial.newproject.user.exeception.BadRequestException.EmailAlreadyExistsException;
-import com.econo_4factorial.newproject.user.exeception.BadRequestException.InvalidBloodTypeException;
 import com.econo_4factorial.newproject.user.exeception.BadRequestException.PhoneNumberAlreadyExistsException;
 import com.econo_4factorial.newproject.user.exeception.BadRequestException.UserNotFoundException;
 import com.econo_4factorial.newproject.user.repository.UserRepository;
@@ -53,9 +52,20 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public Boolean isProfileFilled(Long userId) {
+    public UserStatusInfoDTO isProfileSet(Long userId) {
+        boolean basicInfo = isBasicInfoSet(userId);
+        boolean personalInfo = isPersonalInfoSet(userId);
+        return new UserStatusInfoDTO(basicInfo, personalInfo);
+    }
+
+    private Boolean isBasicInfoSet(Long userId) {
         User user = findUserByIdOrThrow(userId);
-        return user.isProfileFilled();
+        return user.isBasicInfoSet();
+    }
+
+    private Boolean isPersonalInfoSet(Long userId) {
+        User user = findUserByIdOrThrow(userId);
+        return user.isPersonalInfoSet();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
+++ b/src/main/java/com/econo_4factorial/newproject/user/service/UserService.java
@@ -5,7 +5,7 @@ import com.econo_4factorial.newproject.auth.dto.kakao.KakaoUserInfoDTO;
 import com.econo_4factorial.newproject.user.domain.BloodType;
 import com.econo_4factorial.newproject.user.domain.User;
 import com.econo_4factorial.newproject.user.dto.UserAlertSettingDTO;
-import com.econo_4factorial.newproject.user.dto.UserStatusInfoDTO;
+import com.econo_4factorial.newproject.user.dto.ProfileStatusInfoDTO;
 import com.econo_4factorial.newproject.user.dto.req.AddPersonalInformationReq;
 import com.econo_4factorial.newproject.user.dto.req.AlertSettingReq;
 import com.econo_4factorial.newproject.user.dto.req.AddBasicInformationReq;
@@ -52,10 +52,10 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public UserStatusInfoDTO isProfileSet(Long userId) {
+    public ProfileStatusInfoDTO isProfileSet(Long userId) {
         boolean basicInfo = isBasicInfoSet(userId);
         boolean personalInfo = isPersonalInfoSet(userId);
-        return new UserStatusInfoDTO(basicInfo, personalInfo);
+        return new ProfileStatusInfoDTO(basicInfo, personalInfo);
     }
 
     private Boolean isBasicInfoSet(Long userId) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #147 

## 📝작업 내용

> 프로필 설정 여부를 확인하는 S1-11 API에 개인정보 설정 여부를 추가합니다.


```
{
  "data": {
    "userStatusInfoDTO": {
      "isBasicInfoSet": true,
      "isPersonalInfoSet": true
    }
  },
  "status": "success"
}
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 프로필 상태를 기본 정보/개인 정보의 설정 여부로 세분화해 제공합니다. 화면에서 각 항목의 완료 여부를 각각 확인할 수 있습니다.
* 변경 사항
  * 프로필 상태 조회 응답이 단일 완료 여부에서 세부 상태(기본 정보/개인 정보)로 업데이트되었습니다. 이에 따라 연동 및 화면 로직에서 두 항목을 개별적으로 처리하도록 수정이 필요할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->