### PR TITLE
[BE-64] feat: 로그아웃 및 액세스 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
@@ -1,8 +1,10 @@
 package com.econo_4factorial.newproject.auth.controller;
 
-import com.econo_4factorial.newproject.auth.dto.Res.AppleLoginRes;
-import com.econo_4factorial.newproject.auth.dto.Res.KakaoUriRes;
 import com.econo_4factorial.newproject.auth.dto.Req.AppleLoginReq;
+import com.econo_4factorial.newproject.auth.dto.Req.ReissueTokenReq;
+import com.econo_4factorial.newproject.auth.dto.Res.AppleLoginRes;
+import com.econo_4factorial.newproject.auth.dto.Req.AppleLoginReq;
+import com.econo_4factorial.newproject.auth.dto.Res.KakaoUriRes;
 import com.econo_4factorial.newproject.auth.jwt.AuthToken;
 import com.econo_4factorial.newproject.auth.jwt.service.JwtTokenProvider;
 import com.econo_4factorial.newproject.auth.service.OAuthService;
@@ -69,9 +71,8 @@ public class OAuthController {
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급", description = "리프레쉬 토큰을 사용하여 액세스 및 리프레쉬 토큰을 재발급합니다.")
     public ApiResult<ApiResult.SuccessBody<AuthToken>> reissue(
-            @Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
-        String refreshToken = jwtTokenProvider.extractToken(authHeader);
-        AuthToken authToken = oAuthService.reissue(refreshToken);
+            @RequestBody @Valid ReissueTokenReq req) {
+        AuthToken authToken = oAuthService.reissue(req.refreshToken());
         return ApiResponse.success(authToken, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
@@ -59,8 +59,8 @@ public class OAuthController {
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "사용자 로그아웃 처리 및 토큰 블랙리스트 등록")
     public ApiResult<ApiResult.SuccessBody<Void>> logout(
-            @UserId Long userId,
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+            @Parameter(hidden = true) @UserId Long userId,
+            @Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
         String accessToken = jwtTokenProvider.extractToken(authHeader);
         oAuthService.logout(userId, accessToken);
         return ApiResponse.success(null, HttpStatus.OK);
@@ -69,7 +69,7 @@ public class OAuthController {
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급", description = "리프레쉬 토큰을 사용하여 액세스 및 리프레쉬 토큰을 재발급합니다.")
     public ApiResult<ApiResult.SuccessBody<AuthToken>> reissue(
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+            @Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
         String refreshToken = jwtTokenProvider.extractToken(authHeader);
         AuthToken authToken = oAuthService.reissue(refreshToken);
         return ApiResponse.success(authToken, HttpStatus.OK);

--- a/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
@@ -3,7 +3,6 @@ package com.econo_4factorial.newproject.auth.controller;
 import com.econo_4factorial.newproject.auth.dto.Req.AppleLoginReq;
 import com.econo_4factorial.newproject.auth.dto.Req.ReissueTokenReq;
 import com.econo_4factorial.newproject.auth.dto.Res.AppleLoginRes;
-import com.econo_4factorial.newproject.auth.dto.Req.AppleLoginReq;
 import com.econo_4factorial.newproject.auth.dto.Res.KakaoUriRes;
 import com.econo_4factorial.newproject.auth.jwt.AuthToken;
 import com.econo_4factorial.newproject.auth.jwt.service.JwtTokenProvider;

--- a/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/controller/OAuthController.java
@@ -4,7 +4,9 @@ import com.econo_4factorial.newproject.auth.dto.Res.AppleLoginRes;
 import com.econo_4factorial.newproject.auth.dto.Res.KakaoUriRes;
 import com.econo_4factorial.newproject.auth.dto.Req.AppleLoginReq;
 import com.econo_4factorial.newproject.auth.jwt.AuthToken;
+import com.econo_4factorial.newproject.auth.jwt.service.JwtTokenProvider;
 import com.econo_4factorial.newproject.auth.service.OAuthService;
+import com.econo_4factorial.newproject.common.annotation.UserId;
 import com.econo_4factorial.newproject.common.util.HttpHeadersGenerator;
 import com.econo_4factorial.newproject.common.util.RedirectUriBuilder;
 import com.econo_4factorial.newproject.common.util.api.ApiResponse;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 public class OAuthController {
     private final OAuthService oAuthService;
     private final RedirectUriBuilder redirectUriBuilder;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @GetMapping("/kakao/login")
     @Operation(summary = "카카오 로그인 URI 요청", description = "프론트에서 카카오 로그인 페이지로 리다이렉트하기 위한 URI를 반환합니다.")
@@ -37,7 +40,7 @@ public class OAuthController {
 
     @GetMapping("/kakao/callback")
     @Operation(summary = "카카오 로그인 콜백 처리", description = "카카오 로그인 후 리다이렉트된 코드로 사용자 인증을 처리합니다.")
-    public ApiResult<ApiResult.SuccessBody<Void>> loginWithKakao (
+    public ApiResult<ApiResult.SuccessBody<Void>> loginWithKakao(
             @Parameter(description = "카카오 인가 코드", example = "abc123", required = true)
             @RequestParam("code") String kakaoAuthorizationCode) {
         AuthToken authToken = oAuthService.loginWithKaKao(kakaoAuthorizationCode);
@@ -47,8 +50,28 @@ public class OAuthController {
 
     @PostMapping("/apple/login")
     @Operation(summary = "애플 로그인", description = "애플 ID 토큰을 기반으로 로그인 처리합니다.")
-    public ApiResult<ApiResult.SuccessBody<AppleLoginRes>> loginWithApple (@RequestBody @Valid AppleLoginReq appleLoginReq) {
+    public ApiResult<ApiResult.SuccessBody<AppleLoginRes>> loginWithApple(
+            @RequestBody @Valid AppleLoginReq appleLoginReq) {
         AuthToken authToken = oAuthService.loginWithApple(appleLoginReq);
         return ApiResponse.success(AppleLoginRes.from(authToken), HttpStatus.CREATED);
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "사용자 로그아웃 처리 및 토큰 블랙리스트 등록")
+    public ApiResult<ApiResult.SuccessBody<Void>> logout(
+            @UserId Long userId,
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+        String accessToken = jwtTokenProvider.extractToken(authHeader);
+        oAuthService.logout(userId, accessToken);
+        return ApiResponse.success(null, HttpStatus.OK);
+    }
+
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급", description = "리프레쉬 토큰을 사용하여 액세스 및 리프레쉬 토큰을 재발급합니다.")
+    public ApiResult<ApiResult.SuccessBody<AuthToken>> reissue(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+        String refreshToken = jwtTokenProvider.extractToken(authHeader);
+        AuthToken authToken = oAuthService.reissue(refreshToken);
+        return ApiResponse.success(authToken, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/econo_4factorial/newproject/auth/dto/Req/ReissueTokenReq.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/dto/Req/ReissueTokenReq.java
@@ -1,0 +1,9 @@
+package com.econo_4factorial.newproject.auth.dto.Req;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReissueTokenReq(
+    @NotBlank(message = "리프레쉬 토큰은 필수입니다.")
+    String refreshToken
+) {
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/jwt/BlacklistToken.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/jwt/BlacklistToken.java
@@ -1,6 +1,6 @@
 package com.econo_4factorial.newproject.auth.jwt;
 
-import jakarta.persistence.Id;
+import org.springframework.data.annotation.Id;
 import lombok.*;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;

--- a/src/main/java/com/econo_4factorial/newproject/auth/jwt/BlacklistToken.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/jwt/BlacklistToken.java
@@ -1,0 +1,22 @@
+package com.econo_4factorial.newproject.auth.jwt;
+
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "blacklist_token")
+public class BlacklistToken {
+
+    @Id
+    private String accessToken;
+
+    private String status;
+
+    @TimeToLive
+    private Long expirationTime;
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/jwt/BlacklistToken.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/jwt/BlacklistToken.java
@@ -9,7 +9,7 @@ import org.springframework.data.redis.core.TimeToLive;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@RedisHash(value = "blacklist_token")
+@RedisHash(value = "blacklist")
 public class BlacklistToken {
 
     @Id

--- a/src/main/java/com/econo_4factorial/newproject/auth/jwt/repository/BlacklistTokenRepository.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/jwt/repository/BlacklistTokenRepository.java
@@ -1,0 +1,7 @@
+package com.econo_4factorial.newproject.auth.jwt.repository;
+
+import com.econo_4factorial.newproject.auth.jwt.BlacklistToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface BlacklistTokenRepository extends CrudRepository<BlacklistToken, String> {
+}

--- a/src/main/java/com/econo_4factorial/newproject/auth/jwt/service/AuthTokenService.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/jwt/service/AuthTokenService.java
@@ -3,7 +3,10 @@ package com.econo_4factorial.newproject.auth.jwt.service;
 import com.econo_4factorial.newproject.auth.exception.BadRequestException.InvalidRefreshTokenException;
 import com.econo_4factorial.newproject.auth.exception.BadRequestException.LoggedOutTokenException;
 import com.econo_4factorial.newproject.auth.jwt.AuthToken;
+import com.econo_4factorial.newproject.auth.jwt.BlacklistToken;
 import com.econo_4factorial.newproject.auth.jwt.RefreshToken;
+import com.econo_4factorial.newproject.auth.jwt.TokenType;
+import com.econo_4factorial.newproject.auth.jwt.repository.BlacklistTokenRepository;
 import com.econo_4factorial.newproject.auth.jwt.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,6 +21,7 @@ import java.util.Date;
 public class AuthTokenService {
 
     private final RefreshTokenRepository refreshTokenRepository;
+    private final BlacklistTokenRepository blacklistTokenRepository;
     @Value("${custom.jwt.access.expiredTime}")
     private long accessTokenExpiredTime;
     @Value("${custom.jwt.refresh.expiredTime}")
@@ -44,6 +48,8 @@ public class AuthTokenService {
             throw new InvalidRefreshTokenException();
         }
 
+        refreshTokenRepository.deleteById(userId);
+
         return issueAuthToken(userId);
     }
 
@@ -54,12 +60,25 @@ public class AuthTokenService {
     }
 
     @Transactional
-    public void logout(Long userId) {
+    public void logout(Long userId, String accessToken) {
         refreshTokenRepository.deleteById(userId);
+
+        Long expiration = jwtTokenProvider.getExpirationTime(accessToken, TokenType.ACCESS);
+        Long now = new Date().getTime();
+        BlacklistToken blacklistToken = BlacklistToken.builder()
+                .accessToken(accessToken)
+                .status("logout")
+                .expirationTime((expiration - now) / 1000)
+                .build();
+        blacklistTokenRepository.save(blacklistToken);
     }
 
     @Transactional(readOnly = true)
-    public boolean isLoggedIn(Long userId) {
+    public boolean isLoggedIn(Long userId, String accessToken) {
+        if (blacklistTokenRepository.existsById(accessToken)) {
+            throw new LoggedOutTokenException();
+        }
+
         if (!refreshTokenRepository.existsById(userId)) {
             throw new LoggedOutTokenException();
         }

--- a/src/main/java/com/econo_4factorial/newproject/auth/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/jwt/service/JwtTokenProvider.java
@@ -71,6 +71,11 @@ public class JwtTokenProvider {
         return claims.get("id", Long.class);
     }
 
+    public Long getExpirationTime(String token, TokenType tokenType) {
+        Claims claims = getClaimsFromToken(token, tokenType);
+        return claims.getExpiration().getTime();
+    }
+
     private Claims getClaimsFromToken(String token, TokenType tokenType) {
         SecretKey secretKey = tokenType.equals(TokenType.ACCESS) ? accessSecretKey : refreshSecretKey;
         try {

--- a/src/main/java/com/econo_4factorial/newproject/auth/service/OAuthService.java
+++ b/src/main/java/com/econo_4factorial/newproject/auth/service/OAuthService.java
@@ -52,4 +52,12 @@
                 throw new AuthException();
             }
         }
+
+        public void logout(Long userId, String accessToken) {
+            authTokenService.logout(userId, accessToken);
+        }
+
+        public AuthToken reissue(String refreshToken) {
+            return authTokenService.reissue(refreshToken);
+        }
     }

--- a/src/main/java/com/econo_4factorial/newproject/common/config/JwtInterceptor.java
+++ b/src/main/java/com/econo_4factorial/newproject/common/config/JwtInterceptor.java
@@ -49,15 +49,16 @@ public class JwtInterceptor implements HandlerInterceptor {
     }
 
     private boolean isLoggedInRequest(HttpServletRequest request) {
-        Long userId = getUserIdFromAccessToken(request);
-        return authTokenService.isLoggedIn(userId);
+        String accessToken = extractToken(request);
+        Long userId = getUserIdFromAccessToken(accessToken);
+        return authTokenService.isLoggedIn(userId, accessToken);
     }
 
     private String extractToken(HttpServletRequest request) {
         return jwtTokenProvider.extractToken(request.getHeader(HttpHeaders.AUTHORIZATION));
     }
 
-    private Long getUserIdFromAccessToken(HttpServletRequest request) {
-        return jwtTokenProvider.getUserIdFromAccessToken(extractToken(request));
+    private Long getUserIdFromAccessToken(String accessToken) {
+        return jwtTokenProvider.getUserIdFromAccessToken(accessToken);
     }
 }

--- a/src/test/java/com/econo_4factorial/newproject/auth/jwt/service/AuthTokenServiceTest.java
+++ b/src/test/java/com/econo_4factorial/newproject/auth/jwt/service/AuthTokenServiceTest.java
@@ -1,0 +1,141 @@
+package com.econo_4factorial.newproject.auth.jwt.service;
+
+import com.econo_4factorial.newproject.auth.exception.BadRequestException.InvalidRefreshTokenException;
+import com.econo_4factorial.newproject.auth.exception.BadRequestException.LoggedOutTokenException;
+import com.econo_4factorial.newproject.auth.jwt.AuthToken;
+import com.econo_4factorial.newproject.auth.jwt.BlacklistToken;
+import com.econo_4factorial.newproject.auth.jwt.RefreshToken;
+import com.econo_4factorial.newproject.auth.jwt.TokenType;
+import com.econo_4factorial.newproject.auth.jwt.repository.BlacklistTokenRepository;
+import com.econo_4factorial.newproject.auth.jwt.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthTokenServiceTest {
+
+    @InjectMocks
+    private AuthTokenService authTokenService;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private BlacklistTokenRepository blacklistTokenRepository;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    private final Long userId = 1L;
+    private final String accessToken = "mock_access_token";
+    private final String refreshToken = "mock_refresh_token";
+
+    @BeforeEach
+    void setUp() {
+        // @Value 필드 수동 주입
+        ReflectionTestUtils.setField(authTokenService, "accessTokenExpiredTime", 3600L);
+        ReflectionTestUtils.setField(authTokenService, "refreshTokenExpiredTime", 1209600L);
+    }
+
+    @Test
+    @DisplayName("로그인 시 토큰 발급 및 리프레쉬 토큰을 저장한다")
+    void issueAuthToken_success() {
+        // given
+        given(jwtTokenProvider.issueAccessToken(userId)).willReturn(accessToken);
+        given(jwtTokenProvider.issueRefreshToken(userId)).willReturn(refreshToken);
+
+        // when
+        AuthToken result = authTokenService.issueAuthToken(userId);
+
+        // then
+        assertThat(result.accessToken()).isEqualTo(accessToken);
+        assertThat(result.refreshToken()).isEqualTo(refreshToken);
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("재발급 시 RTR 방식에 따라 이전 토큰을 삭제하고 새 토큰을 발급한다")
+    void reissue_success() {
+        // given
+        given(jwtTokenProvider.getUserIdFromRefreshToken(refreshToken)).willReturn(userId);
+        given(refreshTokenRepository.existsByRefreshToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.issueAccessToken(userId)).willReturn("new_access_token");
+        given(jwtTokenProvider.issueRefreshToken(userId)).willReturn("new_refresh_token");
+
+        // when
+        AuthToken result = authTokenService.reissue(refreshToken);
+
+        // then
+        verify(refreshTokenRepository).deleteById(userId); // 이전 토큰 삭제(RTR) 확인
+        verify(refreshTokenRepository).save(any(RefreshToken.class)); // 새 토큰 저장 확인
+        assertThat(result.accessToken()).isEqualTo("new_access_token");
+        assertThat(result.refreshToken()).isEqualTo("new_refresh_token");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 리프레쉬 토큰으로 재발급 시도 시 예외가 발생한다")
+    void reissue_fail_invalid_token() {
+        // given
+        given(jwtTokenProvider.getUserIdFromRefreshToken(refreshToken)).willReturn(userId);
+        given(refreshTokenRepository.existsByRefreshToken(refreshToken)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authTokenService.reissue(refreshToken))
+                .isInstanceOf(InvalidRefreshTokenException.class);
+    }
+
+    @Test
+    @DisplayName("로그아웃 시 리프레쉬 토큰을 삭제하고 액세스 토큰을 블랙리스트에 저장한다")
+    void logout_success() {
+        // given
+        long now = new Date().getTime();
+        long expirationTime = now + 3600000; // 1시간 뒤
+        given(jwtTokenProvider.getExpirationTime(accessToken, TokenType.ACCESS)).willReturn(expirationTime);
+
+        // when
+        authTokenService.logout(userId, accessToken);
+
+        // then
+        verify(refreshTokenRepository).deleteById(userId);
+        verify(blacklistTokenRepository).save(any(BlacklistToken.class));
+    }
+
+    @Test
+    @DisplayName("블랙리스트에 등록된 토큰으로 접근 시 예외가 발생한다")
+    void isLoggedIn_fail_blacklisted() {
+        // given
+        given(blacklistTokenRepository.existsById(accessToken)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> authTokenService.isLoggedIn(userId, accessToken))
+                .isInstanceOf(LoggedOutTokenException.class);
+    }
+
+    @Test
+    @DisplayName("정상 로그인 상태에서는 예외 없이 true를 반환한다")
+    void isLoggedIn_success() {
+        // given
+        given(blacklistTokenRepository.existsById(accessToken)).willReturn(false);
+        given(refreshTokenRepository.existsById(userId)).willReturn(true);
+
+        // when
+        boolean result = authTokenService.isLoggedIn(userId, accessToken);
+
+        // then
+        assertThat(result).isTrue();
+    }
+}

--- a/src/test/java/com/econo_4factorial/newproject/auth/jwt/service/JwtTokenProviderTest.java
+++ b/src/test/java/com/econo_4factorial/newproject/auth/jwt/service/JwtTokenProviderTest.java
@@ -1,7 +1,11 @@
 package com.econo_4factorial.newproject.auth.jwt.service;
 
+import com.econo_4factorial.newproject.auth.exception.BadRequestException.ExpiredTokenException;
+import com.econo_4factorial.newproject.auth.exception.BadRequestException.SignatureException;
 import com.econo_4factorial.newproject.auth.jwt.TokenType;
 import com.econo_4factorial.newproject.auth.jwt.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,9 +13,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.crypto.SecretKey;
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(MockitoExtension.class)
 class JwtTokenProviderTest {
@@ -102,5 +108,39 @@ class JwtTokenProviderTest {
 
         // then
         assertThat(isValid).isTrue();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰을 파싱하면 ExpiredTokenException이 발생한다")
+    void getUserIdFromAccessToken_fail_expiredToken() {
+        // given: 만료 시간이 과거인 토큰 생성
+        SecretKey key = Keys.hmacShaKeyFor(accessSecretKey.getBytes());
+        String expiredToken = Jwts.builder()
+                .claim("id", userId)
+                .issuedAt(new Date(System.currentTimeMillis() - 10000))
+                .expiration(new Date(System.currentTimeMillis() - 5000))
+                .signWith(key)
+                .compact();
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.getUserIdFromAccessToken(expiredToken))
+                .isInstanceOf(ExpiredTokenException.class);
+    }
+
+    @Test
+    @DisplayName("다른 비밀키로 서명된 토큰을 파싱하면 SignatureException이 발생한다")
+    void getUserIdFromAccessToken_fail_invalidSignature() {
+        // given: 다른 비밀키로 서명된 토큰 생성
+        SecretKey wrongKey = Keys.hmacShaKeyFor("wrongSecretKeyThatIsAlsoLongEnoughValue".getBytes());
+        String invalidToken = Jwts.builder()
+                .claim("id", userId)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 3600000))
+                .signWith(wrongKey)
+                .compact();
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.getUserIdFromAccessToken(invalidToken))
+                .isInstanceOf(SignatureException.class);
     }
 }

--- a/src/test/java/com/econo_4factorial/newproject/auth/jwt/service/JwtTokenProviderTest.java
+++ b/src/test/java/com/econo_4factorial/newproject/auth/jwt/service/JwtTokenProviderTest.java
@@ -1,0 +1,106 @@
+package com.econo_4factorial.newproject.auth.jwt.service;
+
+import com.econo_4factorial.newproject.auth.jwt.TokenType;
+import com.econo_4factorial.newproject.auth.jwt.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    private final String accessSecretKey = "testAccessSecretKeyThatIsAtLeast32CharsLong";
+    private final String refreshSecretKey = "testRefreshSecretKeyThatIsAlsoLongEnough";
+    private final Long accessTokenExpiredTime = 3600L;
+    private final Long refreshTokenExpiredTime = 1209600L;
+    private final Long userId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProvider(
+                accessSecretKey,
+                refreshSecretKey,
+                accessTokenExpiredTime,
+                refreshTokenExpiredTime,
+                refreshTokenRepository
+        );
+    }
+
+    @Test
+    @DisplayName("액세스 토큰을 정상적으로 발급하고 유저 ID를 추출한다")
+    void issueAccessToken_and_getUserId_success() {
+        // when
+        String token = jwtTokenProvider.issueAccessToken(userId);
+        Long extractedId = jwtTokenProvider.getUserIdFromAccessToken(token);
+
+        // then
+        assertThat(token).isNotBlank();
+        assertThat(extractedId).isEqualTo(userId);
+    }
+
+    @Test
+    @DisplayName("리프레쉬 토큰을 정상적으로 발급하고 유저 ID를 추출한다")
+    void issueRefreshToken_and_getUserId_success() {
+        // when
+        String token = jwtTokenProvider.issueRefreshToken(userId);
+        Long extractedId = jwtTokenProvider.getUserIdFromRefreshToken(token);
+
+        // then
+        assertThat(token).isNotBlank();
+        assertThat(extractedId).isEqualTo(userId);
+    }
+
+    @Test
+    @DisplayName("토큰의 만료 시간을 정상적으로 추출한다")
+    void getExpirationTime_success() {
+        // given
+        String token = jwtTokenProvider.issueAccessToken(userId);
+        long now = new Date().getTime();
+
+        // when
+        Long expirationTime = jwtTokenProvider.getExpirationTime(token, TokenType.ACCESS);
+
+        // then
+        assertThat(expirationTime).isGreaterThan(now);
+        // 설정한 1시간(3600초) 근처인지 확인 (오차 감안)
+        assertThat(expirationTime - now).isLessThanOrEqualTo(accessTokenExpiredTime * 1000);
+    }
+
+    @Test
+    @DisplayName("Bearer 헤더에서 토큰을 정상적으로 추출한다")
+    void extractToken_success() {
+        // given
+        String authHeader = "Bearer some_jwt_token_value";
+
+        // when
+        String extracted = jwtTokenProvider.extractToken(authHeader);
+
+        // then
+        assertThat(extracted).isEqualTo("some_jwt_token_value");
+    }
+
+    @Test
+    @DisplayName("올바른 리프레쉬 토큰을 검증하면 true를 반환한다")
+    void validateRefreshToken_success() {
+        // given
+        String token = jwtTokenProvider.issueRefreshToken(userId);
+
+        // when
+        boolean isValid = jwtTokenProvider.validateRefreshToken(token);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #26 

## 📝작업 내용

  로그아웃 보안 강화 및 토큰 재발급 로직 구현


   - 로그아웃 고도화 및 블랙리스트 도입
       - AuthTokenService.logout: 로그아웃 시 리프레쉬 토큰을 삭제하고, 액세스 토큰을 Redis 블랙리스트에 등록하여 세션을 무효화했습니다.
       - Redis의 TTL(Time To Live) 기능을 활용해 블랙리스트 토큰이 만료 시간에 맞춰 자동으로 삭제되도록 설계했습니다.
   - 토큰 재발급 RTR(Refresh Token Rotation) 적용
       - AuthTokenService.reissue: 보안 강화를 위해 재발급 요청 시 기존 리프레쉬 토큰을 즉시 무효화하고 새로운 토큰 세트를 발급하는 RTR 방식을 도입했습니다.
   - 인터셉터(Interceptor) 보안 검증 강화
       - JwtInterceptor: 모든 인가 요청 시, 사용 중인 액세스 토큰이 블랙리스트에 등록되어 있는지 실시간으로 검증하는 로직을 추가하여 로그아웃된 토큰의 접근을 차단했습니다.
   - 코드 일관성 리팩토링
       - 블랙리스트 관리를 기존 RefreshToken과 동일한 Repository (@RedisHash) 패턴으로 리팩토링하여 프로젝트 내 데이터 접근 방식의 일관성을 유지했습니다.


  주요 수정 파일
   - AuthTokenService: 로그아웃, 재발급(RTR), 블랙리스트 확인 핵심 로직 구현
   - JwtInterceptor: 블랙리스트 검증 로직 연동
   - JwtTokenProvider: 블랙리스트 TTL 설정을 위한 토큰 만료 시간 추출 로직 추가
   - BlacklistToken, BlacklistTokenRepository: Redis 블랙리스트 관리를 위한 엔티티 및 레포지토리 신규 생성
   - OAuthController, OAuthService: 로그아웃 및 재발급 API 엔드포인트 연동

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
  > - BlacklistToken 엔티티의 ID 어노테이션을 Redis 전용인 org.springframework.data.annotation.Id를 사용하여 패키지 충돌 문제를 해결했습니다. 기존 RefreshToken과 구조가 동일한지 검토 부탁드립니다.
  > - 토큰 재발급 시 헤더를 통해 리프레쉬 토큰을 받는 방식이 프론트엔드 통신 규약과 일치하는지 한 번 더 확인해 주시면 감사하겠습니다. -> 이를, 바디를 통해 리프레쉬 토큰을 전달하는 방식으로 변경했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그아웃 및 토큰 재발급(리프레시 토큰) 공개 API 추가.
  * 리프레시 토큰 요청 형식 추가.

* **보안 개선**
  * 로그아웃 시 액세스 토큰을 즉시 무효화(블랙리스트)해 재사용 차단.
  * 토큰 만료 시간 확인 기능 추가해 만료 검증 강화.
  * 인증 인터셉터가 액세스 토큰 유효성(블랙리스트 포함)을 함께 검사하도록 변경.

* **테스트**
  * 토큰 발급·재발급·로그아웃·블랙리스트·만료 검증 등 단위 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->